### PR TITLE
Codedeploy cicd pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The Herdius Blockchain is an open-source project that welcomes source-code devel
 
 ### Pull Request Instructions
 
-All new pull requests should be submitted to the newest release branch. Release branches are indicated with a preceding `v` and then the release number (eg. `v1.0.0`). Note- no PRs will be accepted to the `master` branch, and will be requested to be redirected.
+All new pull requests should be submitted to `master` in GitHub. Stable releases are marked with a git tag and are indicated with a preceding `v` and then the release number (eg. `v1.0.0`).
 
 For a pull request to be review, apply the GitHub "Ready for Review" label.
 

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,15 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /home/ec2-user/go/src/github.com/herdius/herdius-blockchain-api
+    overwrite: true
+hooks:
+  BeforeInstall:
+    - location: deployment/kill_old_server.sh
+      timeout: 10
+      runas: root
+  AfterInstall:
+     - location: deployment/start_server.sh
+       timeout: 60
+       runas: ec2-user

--- a/deployment/kill_old_server.sh
+++ b/deployment/kill_old_server.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -x
 
-echo "attempting to kill old server process"
+echo "attempting to kill old server proc"
 pkill -f /tmp/go-build
 echo "old server killed"

--- a/deployment/kill_old_server.sh
+++ b/deployment/kill_old_server.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -x
+
+echo "attempting to kill old server process"
+pkill -f /tmp/go-build
+echo "old server killed"

--- a/deployment/start_server.sh
+++ b/deployment/start_server.sh
@@ -2,11 +2,12 @@
 set -ex
 
 export PATH=$PATH:/usr/local/go/bin
+export GO111MODULE=on
 export GOPATH=/home/ec2-user/go
 whoami
 ls -lah
 pwd
 cd /home/ec2-user/go/src/github.com/herdius/herdius-core
 go get ./...
-make start-server ENV=staging > /dev/null 2> /dev/null < /dev/null &
+make start-supervisor ENV=staging > /dev/null 2> /dev/null < /dev/null &
 echo "server started in background"

--- a/deployment/start_server.sh
+++ b/deployment/start_server.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+export PATH=$PATH:/usr/local/go/bin
+export GOPATH=/home/ec2-user/go
+whoami
+ls -lah
+pwd
+cd /home/ec2-user/go/src/github.com/herdius/herdius-core
+go get ./...
+make start-server ENV=staging > /dev/null 2> /dev/null < /dev/null &
+echo "server started in background"


### PR DESCRIPTION
## Problem

We need the latest version of the master branch to be deployed at all times to a stable, persistent EC2 instances with constant IP addresses or endpoints. This need is driven by the higher-level need that we need the community to participate, and reliably interact with the Herdius test chain which is still a work in progress, and a stable way for our core team to test changes we make to the codebase.

## Solution

Create a CICD pipeline for the deployment of new commits to the `master` branch. This specific pipeline lives in AWS' CodeDeploy, EC2, and CodePipeline:

1. [EC2 instance](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances:instanceId=i-0822c9c142ad6c905;sort=desc:launchTime) which new commits are automatically deployed
2. [CodeDeploy application](https://console.aws.amazon.com/codesuite/codedeploy/applications/herdius-core_supervisor?region=us-east-1) which launches the CodePipeline event when new GitHub commits are made.
3. [CodePipeline pipeline](https://console.aws.amazon.com/codesuite/codepipeline/pipelines/herdius-core_supervisor/view) which is webhooked to this GitHub repo. When a new commit is made to the `master` branch in this repo in GitHub:
  1. Stop old supervisor process running on EC2 instance
  2. Update the EC2 instance with new commits
  3. Start the supervisor process with the new codebase on the EC2 instance

## Testing Done and Results

<details>
<summary>Screenshot of CICD pipeline restarting supervisor process</summary>

![image](https://user-images.githubusercontent.com/6162362/56042534-8d80e880-5d3b-11e9-85b3-0128bed47c77.png)

</details>

## Follow-up Work Needed

Ensure that this applies to `master` in the same way that it has applied to the test branches.