### PR TITLE
Using localhost instead of typo; messages need different messagenum

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -1,5 +1,5 @@
 [dev]
-selfbroadcastip = "121.0.0.1"
+selfbroadcastip = "127.0.0.1"
 selfbroadcastport = 3000
 protocol = "tcp"
 chaindbpath = "./herdius/chaindb"


### PR DESCRIPTION
## Problem

1. We are transitioning the API Node to establish [persistent connections with the Supervisor](https://github.com/herdius/herdius-blockchain-api/pull/29). The current Supervisor codebase is not able to allow this type of connection. This is due to the fact that the networking layer keeps track of how many messages have been received per connection and limits this to just 1.
2. There's a typo that's preventing all localhost'd connections from responding correctly.

## Solution

1. Add iterating variable to networking package which keeps track of inbound message numbers per connection. Iterate over next message.
2. Fix typo that allows localhost responses.

## Testing Done and Results

@lmahanand and I both tested this by using simultaneous requests to the API node, which handled it sufficiently.

<summary>local testing</summary>
<detail>

```
 ColeBittel@colesmabookhome  ~ 
 ❯ curl http://localhost:80/account/HPNMnZc9eNA7PzEMRWVqXwzPqieSRLzuyf                                                                            [13:22:13]
{"nonce":0,"address":"HPNMnZc9eNA7PzEMRWVqXwzPqieSRLzuyf","balance":0,"storageRoot":"","publicKey":"EC01895B8168D3A10CD8CE0120ABCE1FF66BA2CDF8D02F1956F5C6DF49FDF207","Balances":{"HER":10000}}

 ColeBittel@colesmabookhome  ~ 
 ❯ curl http://localhost:80/account/HPNMnZc9eNA7PzEMRWVqXwzPqieSRLzuyf                                                                            [13:22:13]
{"nonce":0,"address":"HPNMnZc9eNA7PzEMRWVqXwzPqieSRLzuyf","balance":0,"storageRoot":"","publicKey":"EC01895B8168D3A10CD8CE0120ABCE1FF66BA2CDF8D02F1956F5C6DF49FDF207","Balances":{"HER":10000}}

 ColeBittel@colesmabookhome  ~ 
 ❯ curl http://localhost:80/account/HPNMnZc9eNA7PzEMRWVqXwzPqieSRLzuyf                                                                            [13:22:13]
{"nonce":0,"address":"HPNMnZc9eNA7PzEMRWVqXwzPqieSRLzuyf","balance":0,"storageRoot":"","publicKey":"EC01895B8168D3A10CD8CE0120ABCE1FF66BA2CDF8D02F1956F5C6DF49FDF207","Balances":{"HER":10000}}
```

</detail>

## Follow-up Work Needed

Potentially `messageNum` implementation to be changed to a timestamp, but only a though.
