### PR TITLE
commit trie to underline db too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ run-test:
 
 all: install run-test create_db_dirs
 
-start-supervisor: create_db_dirs
+start-supervisor:
 	@echo "Starting supervisor node"$(GOPARAMETERS)
 	@$(GORUN) cmd/herserver/main.go -supervisor=true$(GOPARAMETERS)
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ delete-db-dirs:
 	@ rm -R ./herdius
 
 create_db_dirs:
-	@ mkdir ./herdius && mkdir ./herdius/chaindb/ && mkdir ./herdius/statedb/
+	@ mkdir -p ./herdius && mkdir -p ./herdius/chaindb/ && mkdir -p ./herdius/statedb/
 
 build: 
 	$(GOBUILD) ./...
@@ -46,7 +46,7 @@ run-test:
 
 all: install run-test create_db_dirs
 
-start-supervisor: delete-db-dirs create_db_dirs
+start-supervisor: create_db_dirs
 	@echo "Starting supervisor node"$(GOPARAMETERS)
 	@$(GORUN) cmd/herserver/main.go -supervisor=true$(GOPARAMETERS)
 


### PR DESCRIPTION
## Problem

Restarting supervisor node was not getting back same account which was loaded before

Asana Link: 

## Solution

Trie was not getting saved in leveldb db

## Testing Done and Results

1) First supervisor node  will create statedb directory and loads default accounts
start-supervisor: delete-db-dirs create_db_dirs
2) Stop supervisor node and start again without deleting statedb directory by removing  delete-db-dirs create_db_dirs
3) Account which was loaded in first run will be available 

## Follow-up Work Needed

This fix just commit trie of  default accounts data, trie.commit() is being used in many places but it is not using internal Trie Interface need to find out the occurence of commit and replave it


Need to finalize the flow at what duration trie should be commited to db, (Will be looking into geth client about this) 
