### PR TITLE
Due to reuse of message nonce replies were not sent back to client

### DIFF
--- a/hbi/message/plugin.go
+++ b/hbi/message/plugin.go
@@ -69,6 +69,7 @@ func (state *TransactionMessagePlugin) Receive(ctx *network.PluginContext) error
 		getTx(txID, ctx)
 
 	case *protoplugin.TxRequest:
+		fmt.Printf("Nonce Value is :: %v\n", nonce)
 		tx := msg.GetTx()
 		accSrv := account.NewAccountService()
 		account, err := accSrv.GetAccountByAddress(msg.Tx.GetSenderAddress())
@@ -91,8 +92,12 @@ func (state *TransactionMessagePlugin) Receive(ctx *network.PluginContext) error
 		//Check Tx.Nonce > account.Nonce
 		if account != nil {
 			if !accSrv.VerifyAccountNonce(account, tx.GetAsset().Nonce) {
-				failedVerificationMsg := "Transaction nonce (" + string(msg.Tx.GetAsset().Nonce) +
-					") should be greater than account nonce (" + string(account.Nonce) + ")"
+
+				txNonce := strconv.FormatUint(msg.Tx.GetAsset().Nonce, 10)
+				accountNonce := strconv.FormatUint(account.Nonce, 10)
+				failedVerificationMsg := "Transaction nonce " + txNonce +
+					" should be greater than account nonce " + accountNonce
+
 				err = apiClient.Reply(network.WithSignMessage(context.Background(), true), nonce,
 					&protoplugin.TxResponse{
 						TxId: "", Status: "failed", Queued: 0, Pending: 0,
@@ -199,6 +204,7 @@ func postAccountUpdateTx(tx *protoplugin.Tx, ctx *network.PluginContext) error {
 		&protoplugin.TxResponse{
 			TxId: txID, Status: "success", Queued: 0, Pending: 0,
 		})
+	nonce++
 	if err != nil {
 		return fmt.Errorf(fmt.Sprintf("Failed to reply to client :%v", err))
 	}

--- a/hbi/message/plugin.go
+++ b/hbi/message/plugin.go
@@ -69,7 +69,6 @@ func (state *TransactionMessagePlugin) Receive(ctx *network.PluginContext) error
 		getTx(txID, ctx)
 
 	case *protoplugin.TxRequest:
-		fmt.Printf("Nonce Value is :: %v\n", nonce)
 		tx := msg.GetTx()
 		accSrv := account.NewAccountService()
 		account, err := accSrv.GetAccountByAddress(msg.Tx.GetSenderAddress())


### PR DESCRIPTION
## Problem

When client sends a TX request with an incorrect Transaction Nonce, it should reply to client that transaction nonce is incorrect. However, replies were getting hung since message nonce was not incremented.

Asana Link: 

## Solution
Nonce value is incremented in the code of `hbi/message/plugin.go` file when blockchain replies to client.
## Testing Done and Results
**Request with the Correct Nonce**

```
9:33AM INF Tx ID : HTx2cd9d9a04bc73edd33dca1bf851c61479b054cb6
2019/04/24 09:33:41 mempool.go:74: mempool txcount after remove: 0
9:33AM INF New Block Added
9:33AM INF Block Id: DE30D0C6FD821FD9D8F88B3FA9B72C967C716FF7601A0C608168ED50FBF306E2
9:33AM INF Last Block Id: 8AB80DA5F0BE34BE807BFD5C659FCBCD1F857CB57521FF5BBC3985E333A235D4
9:33AM INF Block Height: 66
9:33AM INF Timestamp : 2019-04-24 09:07:20 +0530 IST
```
**Request with Incorrect Nonce**

```
9:33AM INF Remaining mempool txcount: 1
9:33AM INF Tx ID : HTx2cd9d9a04bc73edd33dca1bf851c61479b054cb6
2019/04/24 09:33:41 mempool.go:74: mempool txcount after remove: 0
9:33AM INF New Block Added
9:33AM INF Block Id: DE30D0C6FD821FD9D8F88B3FA9B72C967C716FF7601A0C608168ED50FBF306E2
9:33AM INF Last Block Id: 8AB80DA5F0BE34BE807BFD5C659FCBCD1F857CB57521FF5BBC3985E333A235D4
9:33AM INF Block Height: 66
9:33AM INF Timestamp : 2019-04-24 09:07:20 +0530 IST
9:33AM INF State root : 72ABA12363B591B3350D84BF517DFC40B536A74C736102F856AB08C95501EC55
9:39AM ERR %!s(<nil>) error="Transaction nonce 233 should be greater than account nonce 233"
```

## Follow-up Work Needed
