### PR TITLE
Log to file and rewrite; not stdout

### DIFF
--- a/deployment/start_server.sh
+++ b/deployment/start_server.sh
@@ -4,10 +4,9 @@ set -ex
 export PATH=$PATH:/usr/local/go/bin
 export GO111MODULE=on
 export GOPATH=/home/ec2-user/go
-whoami
-ls -lah
-pwd
 cd /home/ec2-user/go/src/github.com/herdius/herdius-core
+mkdir -p /var/log/herdius/herdius-core/log/
+sudo chmod 733 -R /var/log/herdius/
 go get ./...
-make start-supervisor ENV=staging > /dev/null 2> /dev/null < /dev/null &
+make start-supervisor ENV=staging > /var/log/herdius/herdius-core/log/server.log 2> /var/log/herdius/herdius-core/log/server.log < /dev/null &
 echo "server started in background"

--- a/deployment/start_server.sh
+++ b/deployment/start_server.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -ex
 
+LOGDIR=/var/log/herdius/herdius-core/log
 export PATH=$PATH:/usr/local/go/bin
 export GO111MODULE=on
 export GOPATH=/home/ec2-user/go
 cd /home/ec2-user/go/src/github.com/herdius/herdius-core
-mkdir -p /var/log/herdius/herdius-core/log/
+sudo mkdir -p $LOGDIR
 sudo chmod 733 -R /var/log/herdius/
 go get ./...
-make start-supervisor ENV=staging > /var/log/herdius/herdius-core/log/server.log 2> /var/log/herdius/herdius-core/log/server.log < /dev/null &
+make start-supervisor ENV=staging > $LOGDIR/server.log 2> $LOGDIR/server.log < /dev/null &
 echo "server started in background"


### PR DESCRIPTION
## Problem

Logging on remote machines is useless, as the current logging mechanism is to `/dev/null` for both stdout and stderr. Logging is important for us to be able to view for debugging issues.

## Solution

Log all server output to a file in `/var/log/herdius/herdius-blockchain-api/log/server.log` including both stdout and stderr. Delete this file upon new server start, so as to not fill disk space on API node.
