### PR TITLE
Tests and only nonce of +1 can be accepted

### DIFF
--- a/accounts/account/service.go
+++ b/accounts/account/service.go
@@ -104,7 +104,7 @@ func (s *Service) VerifyAccountBalance(a *protobuf.Account, txValue uint64, asse
 // VerifyAccountNonce verifies initiated transaction has Nonce value greater than
 // Nonce value in account
 func (s *Service) VerifyAccountNonce(a *protobuf.Account, txNonce uint64) bool {
-	if txNonce > a.Nonce {
+	if txNonce == a.Nonce+1 {
 		return true
 	}
 	return false

--- a/accounts/account/service_test.go
+++ b/accounts/account/service_test.go
@@ -29,6 +29,30 @@ func TestVerifyAccountBalanceFalse(t *testing.T) {
 	assert.False(t, accService.VerifyAccountBalance(account, 5, "HER"))
 }
 
+func TestVerifyAccountNonceHighFalse(t *testing.T) {
+	acc := &protobuf.Account{Nonce: 1}
+	txNonce := uint64(3)
+	s := NewAccountService()
+	res := s.VerifyAccountNonce(acc, txNonce)
+	assert.False(t, res)
+}
+
+func TestVerifyAccountNonceLowFalse(t *testing.T) {
+	acc := &protobuf.Account{Nonce: 1}
+	txNonce := uint64(0)
+	s := NewAccountService()
+	res := s.VerifyAccountNonce(acc, txNonce)
+	assert.False(t, res)
+}
+
+func TestVerifyAccountNonceTrue(t *testing.T) {
+	acc := &protobuf.Account{Nonce: 1}
+	txNonce := uint64(2)
+	s := NewAccountService()
+	res := s.VerifyAccountNonce(acc, txNonce)
+	assert.True(t, res)
+}
+
 func TestPublicAddressCreation(t *testing.T) {
 	privKey := secp256k1.GenPrivKey()
 


### PR DESCRIPTION
## Problem

1. No tests for `TestAccountNonce`.
2. Only transactions with nonce one greater than the account nonce should be accepted into the memory pool.

## Solution

1. Add tests.
2. `== +1` instead of `>`

## Testing Done and Results

Red-Green tests created and completed.