### PR TITLE
Fix to adding multiple External asset addresses doesn't work

### DIFF
--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -696,7 +696,7 @@ func updateAccount(senderAccount *statedb.Account, tx *pluginproto.Tx) *statedb.
 					eBalance = statedb.EBalance{}
 					eBalance.Address = tx.Asset.ExternalSenderAddress
 					eBalance.Balance = 0
-					eBalance.LastBlockHeight = 0 //tx.Asset.ExternalBlockHeight
+					eBalance.LastBlockHeight = 0
 					eBalance.Nonce = 0
 					eBalances := make(map[string]statedb.EBalance)
 					eBalances[tx.Asset.Symbol] = eBalance
@@ -719,9 +719,12 @@ func updateAccount(senderAccount *statedb.Account, tx *pluginproto.Tx) *statedb.
 			eBalance = statedb.EBalance{}
 			eBalance.Address = tx.Asset.ExternalSenderAddress
 			eBalance.Balance = 0
-			eBalance.LastBlockHeight = 0 //tx.Asset.ExternalBlockHeight
+			eBalance.LastBlockHeight = 0
 			eBalance.Nonce = 0
-			eBalances := make(map[string]statedb.EBalance)
+			eBalances := senderAccount.EBalances
+			if eBalances == nil || len(eBalances) == 0 {
+				eBalances = make(map[string]statedb.EBalance)
+			}
 			eBalances[tx.Asset.Symbol] = eBalance
 			senderAccount.EBalances = eBalances
 			senderAccount.Nonce = tx.Asset.Nonce

--- a/supervisor/service/service_test.go
+++ b/supervisor/service/service_test.go
@@ -79,6 +79,44 @@ func TestRegisterNewETHAddress(t *testing.T) {
 	assert.Equal(t, tx.Asset.ExternalSenderAddress, account.EBalances["ETH"].Address)
 }
 
+func TestRegisterMultipleExternalAssets(t *testing.T) {
+	// First add ETH
+	asset := &pluginproto.Asset{
+		Symbol:                "ETH",
+		ExternalSenderAddress: "0xD8f647855876549d2623f52126CE40D053a2ef6A",
+		Nonce:                 1,
+		Network:               "Herdius",
+	}
+	tx := &pluginproto.Tx{
+		SenderAddress: "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
+		Asset:         asset,
+		Type:          "update",
+	}
+	account := &statedb.Account{
+		Address: "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
+	}
+	account = updateAccount(account, tx)
+	assert.True(t, len(account.EBalances) == 1)
+	assert.Equal(t, tx.Asset.ExternalSenderAddress, account.EBalances["ETH"].Address)
+
+	// Second add BTC
+	asset = &pluginproto.Asset{
+		Symbol:                "BTC",
+		ExternalSenderAddress: "Bitcoin-Address",
+		Nonce:                 2,
+		Network:               "Herdius",
+	}
+	tx = &pluginproto.Tx{
+		SenderAddress: "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
+		Asset:         asset,
+		Type:          "update",
+	}
+
+	account = updateAccount(account, tx)
+	assert.True(t, len(account.EBalances) == 2)
+	assert.Equal(t, tx.Asset.ExternalSenderAddress, account.EBalances["BTC"].Address)
+}
+
 func TestUpdateExternalAccountBalance(t *testing.T) {
 	asset := &pluginproto.Asset{
 		Symbol:                "ETH",
@@ -117,7 +155,7 @@ func TestUpdateExternalAccountBalance(t *testing.T) {
 	assert.Equal(t, uint64(15), account.EBalances["ETH"].Balance)
 }
 
-func TestisExternalAssetAddressExistTrue(t *testing.T) {
+func TestIsExternalAssetAddressExistTrue(t *testing.T) {
 	eBal := statedb.EBalance{
 		Address: "0xD8f647855876549d2623f52126CE40D053a2ef6A",
 	}
@@ -129,7 +167,7 @@ func TestisExternalAssetAddressExistTrue(t *testing.T) {
 	}
 	assert.True(t, isExternalAssetAddressExist(account, "ETH"))
 }
-func TestisExternalAssetAddressExistFalse(t *testing.T) {
+func TestIsExternalAssetAddressExistFalse(t *testing.T) {
 	eBal := statedb.EBalance{}
 	eBals := make(map[string]statedb.EBalance)
 	eBals["ETH"] = eBal


### PR DESCRIPTION
## Problem
While registering multiple external address to an account, current external address entry replaces the old one in the map.

For example, below is an entry of ETH present in the **EBalances** field.

`{"Nonce":"7","Address":"H8mRDupEc8s1Zmp6rbT88pispJ1BJCB7sj","PublicKey":"AoxCritcTHTGhDCnsGyUqm9NSt98U8hlC6IlvN5oms7W","StateRoot":"","AddressHash":"","Balance":"13","EBalances":{"ETH":{"Address":"0xD8f647855876549d2623f52126CE40D053a2ef6A","Balance":"300","LastBlockHeight":"0","Nonce":"0"}}}`

If I try to add BTC entry to it, then ETH entry is removed and BTC entry is only present in **EBalances** field.
`{"Nonce":"8","Address":"H8mRDupEc8s1Zmp6rbT88pispJ1BJCB7sj","PublicKey":"AoxCritcTHTGhDCnsGyUqm9NSt98U8hlC6IlvN5oms7W","StateRoot":"","AddressHash":"","Balance":"13","EBalances":{"BTC":{"Address":"0xD8f647855876549d2623f52126CE40D053a2ef6A","Balance":"0","LastBlockHeight":"0","Nonce":"0"}}}`

Map appending logic needs to be fixed.
Asana Link: 
[external asset appending issue](https://app.asana.com/0/998359196895599/1123515875823814)
## Solution
Implemented the correct logic to append new external asset entries.
## Testing Done and Results
1. Created an unit test case to add multiple assets: (Checked for ETH and BTC)
2. Sent 2 transactions to make ETH and BTC entries in **EBalances** field.

Output:
`{"nonce":6,"address":"HBQTafztuPCvGuBwF3L8GdyNTTX8NL99d6","balance":1,"storageRoot":"65FCE479504B02F30E4CC1F0212A5815D0627152BEE6814A850E15A04588D2CA","publicKey":"AhOEabFZgIJKsfIFtVqIS+CWSVp0uQ1wjDj6S7ybA1OH","EBalances":{"BTC":{"Address":"0xD8f647855876549d2623f52126CE40D053a2ef6A","Balance":101,"LastBlockHeight":0,"Nonce":0},"ETH":{"Address":"0xD8f647855876549d2623f52126CE40D053a2ef6A","Balance":200,"LastBlockHeight":0,"Nonce":0}}}`

## Follow-up Work Needed
