### PR TITLE
Infura project id integeration

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -7,7 +7,7 @@ statedbpath = "./herdius/statedb"
 badgerdb = "badger"
 leveldb = "goleveldb"
 nodekeydir = "./supervisor/testdata/"
-ethrpc = "https://ropsten.infura.io"
+ethrpc = "https://ropsten.infura.io/v3/"
 hercontractaddress = "0x7562157d0bbb6d78935133bf06ae279e707aa9ad"
 
 
@@ -20,7 +20,7 @@ statedbpath = "./herdius/statedb"
 badgerdb = "badger"
 leveldb = "goleveldb"
 nodekeydir = "./supervisor/testdata/"
-ethrpc = "https://ropsten.infura.io"
+ethrpc = "https://ropsten.infura.io/v3/"
 
 
 [prod]
@@ -31,5 +31,5 @@ chaindbpath = "./herdius/chaindb"
 statedbpath = "./herdius/statedb"
 badgerdb = "badger"
 leveldb = "goleveldb"
-ethrpc = "https://ropsten.infura.io"
+ethrpc = "https://mainnet.infura.io/v3/"
 

--- a/syncer/account.go
+++ b/syncer/account.go
@@ -2,6 +2,8 @@ package sync
 
 import (
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/ethereum/go-ethereum/common"
 	ethtrie "github.com/ethereum/go-ethereum/trie"
@@ -19,7 +21,10 @@ func SyncAllAccounts(cache *cache.Cache) {
 	if err != nil {
 		fmt.Println("Config file not found...")
 	} else {
+		infuraProjectID := os.Getenv("ROPSTENPROJECTKEY")
 		ethrpc = viper.GetString("dev.ethrpc")
+		ethrpc = ethrpc + infuraProjectID
+		log.Printf("Infura Ropsten Url with Project ID: %v\n", ethrpc)
 		hercontractaddress = viper.GetString("dev.hercontractaddress")
 
 	}

--- a/syncer/account.go
+++ b/syncer/account.go
@@ -21,10 +21,10 @@ func SyncAllAccounts(cache *cache.Cache) {
 	if err != nil {
 		fmt.Println("Config file not found...")
 	} else {
-		infuraProjectID := os.Getenv("ROPSTENPROJECTKEY")
+		infuraProjectID := os.Getenv("INFURAID")
 		ethrpc = viper.GetString("dev.ethrpc")
 		ethrpc = ethrpc + infuraProjectID
-		log.Printf("Infura Ropsten Url with Project ID: %v\n", ethrpc)
+		log.Printf("Infura Url with Project ID: %v\n", ethrpc)
 		hercontractaddress = viper.GetString("dev.hercontractaddress")
 
 	}

--- a/syncer/eth.go
+++ b/syncer/eth.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"math/big"
 
@@ -55,9 +54,6 @@ func (es *EthSyncer) Update() {
 		if ok {
 			//last-balance < External-ETH
 			//Balance of ETH in H = Balance of ETH in H + ( Current_External_Bal - last_External_Bal_In_Cache)
-			fmt.Printf("Address: %v\n", es.Account.Address)
-			fmt.Printf("es.ExtBalance : %v\n", es.ExtBalance)
-			fmt.Printf("last.(cache.AccountCache) : %v\n", last.(cache.AccountCache).LastExtBalance)
 			lastExtBalance, ok := last.(cache.AccountCache).LastExtBalance[assetSymbol]
 			if ok {
 				if lastExtBalance.Cmp(es.ExtBalance) < 0 {


### PR DESCRIPTION
## Problem
Sometime when we try to access services of ethereum networks through Infura, we get the below error.

Error getting ETH Balance from RPC 429 Too Many Requests {"jsonrpc":"2.0","error":{"code":-32005,"message":"legacy access request rate exceeded","data":{"reason":"project ID not provided","see":"https://infura.io/dashboard"

Hence, accessing api services in infura needs a project id to be used.

Need to add the Project ID to environment variable **INFURAID**.
export INFURAID=PROJECT-ID
Asana Link: 

## Solution
Set the environment variable with INFURAID
## Testing Done and Results
make run-test executed for all the tests.
Sent transactions and they are working fine.
Sent transaction to retrieve the balance from Ethereum chain and it is correctly getting updated.
## Follow-up Work Needed
