### PR TITLE
Temp file location was invalid

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -176,7 +176,7 @@ func (b *Backuper) backupToS3(uploader *s3manager.Uploader, baseBlock *protobuf.
 	fileName := "tmpfile.txt"
 
 	// TODO CHANGE AWAY FROM MY OWN HOME DIR
-	tmpFile, err := ioutil.TempFile("/Users/bittelc/go/src/github.com/herdius/herdius-blockchain-api", fileName)
+	tmpFile, err := ioutil.TempFile("", fileName)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create tmpfile %v: %v", fileName, err)
 	}

--- a/deployment/start_server.sh
+++ b/deployment/start_server.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
-LOGDIR=/var/log/herdius/herdius-core/log
+export LOGDIR=/var/log/herdius/herdius-core/log
 export PATH=$PATH:/usr/local/go/bin
 export GO111MODULE=on
 export GOPATH=/home/ec2-user/go
+export AWS_REGION=eu-central-1
 cd /home/ec2-user/go/src/github.com/herdius/herdius-core
 sudo mkdir -p $LOGDIR
 sudo chmod 733 -R /var/log/herdius/


### PR DESCRIPTION
## Problem

Self-explanatory.
The tempfile location for the S3 backups is invalid. Server unable to push due to this.

Also need a region.

## Solution

Fix location so as to create tmpfile in current directory