### PR TITLE
slow down block flush period

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ else
 endif
 
 ifeq (,$(subst ,,$(WAITTIME)))
-	GOPARAMETERS := $(GOPARAMETERS) '-waitTime=3'
+	GOPARAMETERS := $(GOPARAMETERS) '-waitTime=15'
 else
 	GOPARAMETERS := $(GOPARAMETERS) '-waitTime='$(WAITTIME)
 endif

--- a/cmd/herserver/main.go
+++ b/cmd/herserver/main.go
@@ -215,7 +215,7 @@ func main() {
 	groupSizeFlag := flag.Int("groupsize", 3, "# of peers in a validator group")
 	portFlag := flag.Int("port", 0, "port to bind validator to")
 	envFlag := flag.String("env", "dev", "environment to build network and run process for")
-	waitTimeFlag := flag.Int("waitTime", 3, "time to wait before the Memory Pool is flushed to a new block")
+	waitTimeFlag := flag.Int("waitTime", 15, "time to wait before the Memory Pool is flushed to a new block")
 	flag.Parse()
 
 	env := *envFlag


### PR DESCRIPTION
## Problem

We're flushing the mempool way too fast on staging. We already have over 180k blocks in the chain, and most of those contain no transactions.

If we are to backup the entire chain to S3, this will be prohibitively expensive.

## Solution

Slowing down the block creation period is a step forward in limiting our S3 costs. However, it will not be enough if we are to include all account data in each block.
## Testing Done and Results

## Follow-up Work Needed

Add account data into each `baseBlock` pushed to S3.
