### PR TITLE
Open file limiter

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -141,6 +141,7 @@ func (b *Backuper) BackupNeededBaseBlocks(newBlock *protobuf.BaseBlock) error {
 						res, err := b.backupToS3(uploader, unbacked)
 						if err != nil {
 							log.Println("nonfatal: could not backup base block to S3:", err)
+							return
 						}
 						log.Printf("debugging: %+v", res)
 						log.Println("Block backed up to S3:", res.Location)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -143,16 +143,15 @@ func (b *Backuper) BackupNeededBaseBlocks(newBlock *protobuf.BaseBlock) error {
 							log.Println("nonfatal: could not backup base block to S3:", err)
 							return
 						}
-						log.Printf("debugging: %+v", res)
 						log.Println("Block backed up to S3:", res.Location)
 						added++
+						return
 					}
 				}
 			}()
 		}
 		return nil
 	})
-	time.Sleep(1 * time.Minute)
 	for i := 0; i < cap(sem); i++ {
 		sem <- true
 	}

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -114,11 +114,9 @@ func (b *Backuper) BackupNeededBaseBlocks(newBlock *protobuf.BaseBlock) error {
 				return fmt.Errorf("cannot unmarshal db block into struct block: %v", err)
 			}
 			blockHash = block.Header.Block_ID.BlockHash
-			log.Printf("block height-hash: %v-%v", block.Header.Height, blockHash)
 
 			sem <- true
 			go func(blockHash common.HexBytes) {
-				log.Printf("proceeding to search for block in S3 height-hash: %v-%v", block.Header.Height, blockHash)
 				found, err := b.findInS3(svc, block)
 				if err != nil {
 					log.Println("nonfatal: while attempting full chain backup, error while searching for block", err)
@@ -159,7 +157,6 @@ func (b *Backuper) findInS3(svc *s3.S3, baseBlock *protobuf.BaseBlock) (bool, er
 	blockHash = blockHashBz
 	blockHeight := strconv.FormatInt(baseBlock.Header.Height, 10)
 	prefixPattern := fmt.Sprintf("%v-%v", blockHeight, blockHash)
-	log.Println("prefixPattern:", prefixPattern)
 	search := &s3.ListObjectsV2Input{
 		Bucket: aws.String(b.Bucket),
 		Prefix: aws.String(prefixPattern),
@@ -168,7 +165,6 @@ func (b *Backuper) findInS3(svc *s3.S3, baseBlock *protobuf.BaseBlock) (bool, er
 	if err != nil {
 		return false, fmt.Errorf("could not list previous block in S3: %v", err)
 	}
-	log.Printf("result.Contents:\n%+v", result.Contents)
 	if len(result.Contents) <= 0 {
 		return false, nil
 	}

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -140,8 +140,9 @@ func (b *Backuper) BackupNeededBaseBlocks(newBlock *protobuf.BaseBlock) error {
 						log.Printf("not found in S3, beginning backup: %v-%v", unbacked.Header.Height, blockHash)
 						res, err := b.backupToS3(uploader, unbacked)
 						if err != nil {
-							log.Printf("nonfatal: could not backup base block to S3: %v", err)
+							log.Println("nonfatal: could not backup base block to S3:", err)
 						}
+						log.Printf("debugging: %+v", res)
 						log.Println("Block backed up to S3:", res.Location)
 						added++
 					}
@@ -150,6 +151,7 @@ func (b *Backuper) BackupNeededBaseBlocks(newBlock *protobuf.BaseBlock) error {
 		}
 		return nil
 	})
+	time.Sleep(1 * time.Minute)
 	for i := 0; i < cap(sem); i++ {
 		sem <- true
 	}

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -117,6 +117,7 @@ func (b *Backuper) BackupNeededBaseBlocks(newBlock *protobuf.BaseBlock) error {
 
 			sem <- true
 			go func(blockHash common.HexBytes) {
+				defer func() { <-sem }()
 				found, err := b.findInS3(svc, block)
 				if err != nil {
 					log.Println("nonfatal: while attempting full chain backup, error while searching for block", err)
@@ -137,7 +138,6 @@ func (b *Backuper) BackupNeededBaseBlocks(newBlock *protobuf.BaseBlock) error {
 				}
 				log.Println("Block backed up to S3:", res.Location)
 				added++
-				<-sem
 			}(blockHash)
 		}
 		return nil


### PR DESCRIPTION
## WIP

Before merging this in, we need to evaluate the AWS charges that were incurred on June 4th, which is when I ran an entire chain backup for testing of this PR. The EC2 instance, at the time, was in us-east-1 while the S3 bucket is in Frankfurt.

## Problem

[Asana Link](https://app.asana.com/0/998359196895599/1125294787698550)

The blockchain backup logic that attempts to backup the entire chain to S3 does so by opening out a series of goroutines, one for each unbacked block.
While the number of goroutines that a decent Linux server can have is somewhere north of a several millions, the number of open files a linux server can handle is in the tens of thousands*.

This is causing an issue because in order to write to S3, we must create temporary (open) files to upload. And because the blockchain in staging is already in the tens of thousands in length, we are hitting the open file limit and the server is panicking.

```
2019/05/31 09:26:49 aws.go:116: block height-hash: 29584-310518E4F03AADDC916945E45B73B616C110BE75A0165098BDFE063AE3079562
2019/05/31 09:26:49 aws.go:118: proceeding to search for block in S3 height-hash: 40386-310518E4F03AADDC916945E45B73B616C110BE75A0165098BDFE063AE3079562
2019/05/31 09:26:49 aws.go:159: Bucket to search: herdius-blockchain-backup-staging
2019/05/31 09:26:49 aws.go:116: block height-hash: 99352-31075416DB579C6B367EC554360133ADD179FED5224EB412BB694DF6A827B920
2019/05/31 09:26:49 aws.go:118: proceeding to search for block in S3 height-hash: 21875-31075416DB579C6B367EC554360133ADD179FED5224EB412BB694DF6A827B920
2019/05/31 09:26:49 aws.go:159: Bucket to search: herdius-blockchain-backup-staging
2019/05/31 09:26:49 aws.go:116: block height-hash: 19024-3107AF0D716DD7D68C8BC428A03362200843FE01D3F190EA71E149C6AB274E48
2019/05/31 09:26:49 aws.go:118: proceeding to search for block in S3 height-hash: 18029-3107AF0D716DD7D68C8BC428A03362200843FE01D3F190EA71E149C6AB274E48
2019/05/31 09:26:49 aws.go:159: Bucket to search: herdius-blockchain-backup-staging
2019/05/31 09:26:49 aws.go:116: block height-hash: 40709-3107C77CF9DB5264728493533BA5E5BBDDAC5A25B05C174F9C2EEC87B3E4C951
2019/05/31 09:26:49 aws.go:116: block height-hash: 107373-31084063D8E24C9A23703FDAAA211630F759F9F4B63FB17382D2D82265CA918E
2019/05/31 09:26:49 aws.go:116: block height-hash: 55449-3108816C15BDCCD4C0CCD89F62EDFB4AF6296687F6F9B41CD212C55A4A4EC7CD
2019/05/31 09:26:49 aws.go:116: block height-hash: 75899-31093FA51A28896531C68D13046A899FEBEE964398F67D5BB0654F2DD243F6AF
2019/05/31 09:26:49 aws.go:116: block height-hash: 61037-3109D587C31C4FBCBF264BC196B8DB6CCB2EBC13C3129BA43F6ED04CE709B618
2019/05/31 09:26:49 aws.go:116: block height-hash: 69085-310B0F7CD336037E5ECC9FF22B4C20585B24F32B7BAF6A851BAAEABC630CE532
2019/05/31 09:26:49 aws.go:116: block height-hash: 21702-310B692FFB2BED2FE93A7026A24071DA65A3EBAF0ECD9FE3A3CC9ADDEBA38DC9
2019/05/31 09:26:49 aws.go:116: block height-hash: 33647-310B8254A269143676FB1EB77AF28753D9EA88A7DE50000FFC189601085D0114
2019/05/31 09:26:49 aws.go:116: block height-hash: 25856-310C58EC4EF38F06A618FA956C247E9A6AF7752D9F487051F3D09DB283199115
2019/05/31 09:26:49 aws.go:116: block height-hash: 101117-310CB599002D77A0C2959A85A9395FB40045F065687DF456E54EAB03A955A3AA
2019/05/31 09:26:49 aws.go:118: proceeding to search for block in S3 height-hash: 910-310CB599002D77A0C2959A85A9395FB40045F065687DF456E54EAB03A955A3AA
2019/05/31 09:26:49 aws.go:159: Bucket to search: herdius-blockchain-backup-staging
2019/05/31 09:26:47 aws.go:125: not found in S3: 7252-30BF4BCFD60A9B8AE49ADACE60C7426D0A3ADA948B2DCBDFB16CE88A4DD4266B
2019/05/31 09:26:49 aws.go:136: not found in S3, beginning backup: 7252-310CB599002D77A0C2959A85A9395FB40045F065687DF456E54EAB03A955A3AA
2019/05/31 09:26:49 aws.go:139: nonfatal: could not backup base block to S3: cannot create tmpfile tmpfile.txt: open /tmp/tmpfile.txt373921439: too many open files
2019/05/31 09:26:49 aws.go:131: Blocks backed up to S3: 0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xd33943]

goroutine 378 [running]:
github.com/herdius/herdius-core/aws.(*Backuper).BackupNeededBaseBlocks.func1.2(0xc00bbfda38, 0xc00bc35320, 0xc00bc3d1c0, 0xc00ba537e0, 0xc00bbbe050)
	/home/ec2-user/go/src/github.com/herdius/herdius-core/aws/aws.go:141 +0x63
created by github.com/herdius/herdius-core/aws.(*Backuper).BackupNeededBaseBlocks.func1
	/home/ec2-user/go/src/github.com/herdius/herdius-core/aws/aws.go:129 +0x29a
exit status 2
make: *** [start-supervisor] Error 1
```

## Solution

Limit concurrency of S3 uploading to 200 threads. The default open file limit on a Linux instance, such as the one we have running the staging Supervisor, is 1024 open files. Many of these are used by the userspace itsellf (eg. log files). An attempt at 1000 open files failed, thus 200 is a conservative estimate.

## Testing Done and Results

Deployed to staging:
<details>
<summary>Deployed to staging</summary>

```
2019/06/04 09:14:22 aws.go:127: block found in s3 while backing up entire chain: 151732-FFF2D249015FBD934B44C1FD59B00C7DFA55ADA00FA6360BD428D41F0048F784
2019/06/04 09:14:22 aws.go:127: block found in s3 while backing up entire chain: 9563-FFFB92161FA842BF58B1BCB3DBB5E0F207D0A4FC0A620EAE4E5668747B53AE54
2019/06/04 09:14:22 aws.go:127: block found in s3 while backing up entire chain: 75733-FFF399ADA8F3C96EFE17496417C4AB4B89258866634C861FB6D201807E82C535
2019/06/04 09:14:22 aws.go:127: block found in s3 while backing up entire chain: 115768-FFF6CF08092485EEF9778F25400295C4A31AE2344FE3FD576DD84F0E359AC16C
2019/06/04 09:14:22 aws.go:127: block found in s3 while backing up entire chain: 50437-FFFE55B49CC8E98E4E9416C0841EE50A1D6B470B75219C96F81DCE7F9C33F99C
2019/06/04 09:14:22 aws.go:127: block found in s3 while backing up entire chain: 181837-FFFAD8C2C48B7F56525E07D17833200A99B906B52D250028E9A65E9B33A7945A
2019/06/04 09:14:22 aws.go:149: finished adding to cap semaphore; returning
2019/06/04 09:14:22 service.go:362: Sucessfully re-evaluated chain and backed up to S3
{"level":"info","time":"2019-06-04T09:14:22Z","message":"New Block Added"}
{"level":"info","time":"2019-06-04T09:14:22Z","message":"Block Id: BC3537B1F498AD21AE0C5D822E6159F015155A4143C556A6CDBE8650EF7F62B6"}
{"level":"info","time":"2019-06-04T09:14:22Z","message":"Last Block Id: FD7C315355BF9D4241167450E1494B2A4E24A585B2AE0B364A27C3AB37EB749A"}
{"level":"info","time":"2019-06-04T09:14:22Z","message":"Block Height: 193639"}
{"level":"info","time":"2019-06-04T09:14:22Z","message":"Timestamp : 2019-06-04 09:09:26 +0000 UTC"}
{"level":"info","time":"2019-06-04T09:14:22Z","message":"State root : D37CBB97276B8DD8191D16303A37FC20F611E58DF7F28BD6EF96CB4B4FA00DF0"}
```

</details>

## Follow-up Work Needed

Move Supervisor nodes to eu-west-1 (Frankfurt) to be in same region as S3 bucket.