### PR TITLE
Add state to backup

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -160,9 +160,6 @@ func (b *Backuper) BackupNeededBaseBlocks(newBlock *protobuf.BaseBlock) error {
 		sem <- struct{}{}
 	}
 	log.Printf("Finished backing up all blocks; added blocks: %v, chain height: %v, blocks failed to backup: %v", added, height, failed)
-	if added <= 0 {
-		return err
-	}
 	err = b.backupStateDB(uploader, height)
 	if err != nil {
 		return fmt.Errorf("Nonfatal: could not backup state DB to S3: %v", err)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -139,7 +139,7 @@ func (b *Backuper) BackupNeededBaseBlocks(newBlock *protobuf.BaseBlock) error {
 					log.Printf("Block found in s3 while backing up entire chain: %v-%v", block.Header.Height, blockHash)
 					return
 				}
-				log.Printf("Block not found in S3, backing up: %v-%v", block.Header.Height, blockHash)
+				log.Printf("Block not found in S3, backing up: /%v/blocks/%v", block.Header.Height, blockHash)
 				res, err := b.backupBlock(uploader, block)
 				if err != nil {
 					log.Println("Nonfatal: could not backup base block to S3:", err)
@@ -175,7 +175,7 @@ func (b *Backuper) findBlockInS3(svc *s3.S3, baseBlock *protobuf.BaseBlock) (boo
 	blockHashBz := baseBlock.GetHeader().GetBlock_ID().GetBlockHash()
 	blockHash = blockHashBz
 	blockHeight := strconv.FormatInt(baseBlock.Header.Height, 10)
-	prefixPattern := fmt.Sprintf("/%v/blocks/%v", blockHeight, blockHash)
+	prefixPattern := fmt.Sprintf("%v/blocks/%v", blockHeight, blockHash)
 	search := &s3.ListObjectsV2Input{
 		Bucket: aws.String(b.Bucket),
 		Prefix: aws.String(prefixPattern),

--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -395,7 +395,7 @@ func (s *Supervisor) ProcessTxs(lastBlock *protobuf.BaseBlock, net *network.Netw
 
 			succ, err := backuper.TryBackupBaseBlock(lastBlock, baseBlock)
 			if err != nil {
-				log.Println("nonfatal: failed to backup new block to S3:", err)
+				log.Println("nonfatal: failed to backup to S3:", err)
 			} else if !succ {
 				log.Println("S3 backup criteria not met; proceeding to backup all unbacked base blocks")
 				err := backuper.BackupNeededBaseBlocks(baseBlock)


### PR DESCRIPTION
## Problem

[Asana Link](https://app.asana.com/0/998359196895599/1123967465533063)

We are currently backing up all the blocks into S3 that are created by the Supervisor ("singular blocks"). However, this does not bring to fruition the need for a disaster recovery process in which the entire chain is backed up and can be restored.

This is because the statedb data is also necessary for restoring the state of the blockchain.

## Solution

Backup all files in the `herdius/statedb/` directory.

* When a new block is added to the chain, both the new block is uploaded to S3, and the updated statedb files are uploaded to S3.
* When all new blocks are retroactively assessed and then uploaded to S3, only the latest block in the evaluation receives the latest updated statedb files.

The S3 directory structure is:
```
<block height>/blocks/<block hash>
<block height>/statedb/<MANIFEST VALUE>/<all files>
```
Where all block uploaded to the first path and all statedb uploads go to the second. `MANIFEST VALUE` represents the contents in the local file `herdius/statedb/CURRENT`.

## Testing Done and Results

```
╰─➤  go run cmd/herserver/main.go -supervisor=true -groupsize=3 -peers=tcp://127.0.0.1:3002 -port=3000 -env=dev
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.Timestamp
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.AccountRegisterRequest
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.EBalance
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.ID
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.ChildBlock
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.Message
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.Ping
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.Pong
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.LookupNodeRequest
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.LookupNodeResponse
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.Bytes
2019/06/07 12:20:57 proto: duplicate proto type registered: protobuf.Timestamp
2019/06/07 12:20:57 value.go:758: Replaying from value pointer: {Fid:0 Len:0 Offset:0}
2019/06/07 12:20:57 value.go:771: Iterating file id: 0
2019/06/07 12:20:57 value.go:774: Iteration took: 40.253µs
2019/06/07 12:20:57 utils.go:82: No peers discovered in network, retrying
12:20PM INF Listening for peers. address=tcp://127.0.0.1:3000
2019/06/07 12:20:57 value.go:758: Replaying from value pointer: {Fid:0 Len:0 Offset:0}
2019/06/07 12:20:57 value.go:771: Iterating file id: 0
2019/06/07 12:20:57 value.go:774: Iteration took: 1.42859ms
12:20PM INF Last Block Hash: 5E2D1A841C55C9597F761A434BAD437324DA8B33EDF933C843188A9E4C987D34
12:20PM INF Height: 49
12:20PM INF Timestamp: 2019-06-07 12:06:12 +0200 CEST
12:20PM INF State root: CB5D298E8E25DBC8210889D8D31AC7A956384444024EC08A2FEF704251094542
2019/06/07 12:20:57 account.go:33: Infura Url with Project ID: https://ropsten.infura.io/v3/70a3313a4c414b5da283fa9bcaf0ed0a

2019/06/07 12:21:00 utils.go:82: No peers discovered in network, retrying
2019/06/07 12:21:03 utils.go:82: No peers discovered in network, retrying
2019/06/07 12:21:06 utils.go:82: No peers discovered in network, retrying
2019/06/07 12:21:09 utils.go:82: No peers discovered in network, retrying
2019/06/07 12:21:12 utils.go:82: No peers discovered in network, retrying
2019/06/07 12:21:12 service.go:389: Block creation wait time (15) elapsed, creating singular base block but with 0 transactions
2019/06/07 12:21:12 service.go:469: Total Accounts to update 0
2019/06/07 12:21:15 utils.go:82: No peers discovered in network, retrying
2019/06/07 12:21:15 aws.go:76: Uploaded base block file to S3: https://herdius-blockchain-backup-dev.s3.eu-central-1.amazonaws.com/50/blocks/7F4CAEA0DC2049D1E9C839895F890555DDA4F98A8C1DE25DB998014C9A15CCAA
2019/06/07 12:21:16 aws.go:258: State DB files uploaded: [herdius/statedb/000002.ldb, herdius/statedb/000093.log, herdius/statedb/CURRENT, herdius/statedb/CURRENT.bak, herdius/statedb/LOCK, herdius/statedb/LOG, herdius/statedb/MANIFEST-000094]
12:21PM INF New Block Added
12:21PM INF Block Id: 7F4CAEA0DC2049D1E9C839895F890555DDA4F98A8C1DE25DB998014C9A15CCAA
12:21PM INF Last Block Id: 5E2D1A841C55C9597F761A434BAD437324DA8B33EDF933C843188A9E4C987D34
12:21PM INF Block Height: 50
12:21PM INF Timestamp : 2019-06-07 12:06:12 +0200 CEST
12:21PM INF State root : CB5D298E8E25DBC8210889D8D31AC7A956384444024EC08A2FEF704251094542

```

## Follow-up Work Needed

Implement restore method
