### PR TITLE
cmd/herserver: fix missing set state root

### DIFF
--- a/cmd/herserver/main.go
+++ b/cmd/herserver/main.go
@@ -347,6 +347,7 @@ func main() {
 
 			lastBlock := blockchainSvc.GetLastBlock()
 			stateRoot = lastBlock.GetHeader().GetStateRoot()
+			supsvc.SetStateRoot(stateRoot)
 			baseBlock, err := supsvc.ProcessTxs(lastBlock, net)
 			if err != nil {
 				log.Error().Msg(err.Error())


### PR DESCRIPTION
## Problem

After https://github.com/herdius/herdius-core/pull/72, sometimes get account details returns nothing for existed account

## Solution

Add missing set state root.

## Testing Done and Results

Passed.

## Follow-up Work Needed
