### PR TITLE
syncer: support migrating from old account

### DIFF
--- a/storage/state/statedb/account.go
+++ b/storage/state/statedb/account.go
@@ -6,16 +6,16 @@ import (
 
 // Account : Account Detail
 type Account struct {
-	Nonce                 uint64
-	Address               string
-	PublicKey             string
-	StateRoot             string
-	AddressHash           cmn.HexBytes
-	Balance               uint64
-	Erc20Address          string
-	LastBlockHeight       uint64
-	ExternalNonce         uint64
-	EBalances             map[string]map[string]EBalance
+	Nonce                uint64
+	Address              string
+	PublicKey            string
+	StateRoot            string
+	AddressHash          cmn.HexBytes
+	Balance              uint64
+	Erc20Address         string
+	LastBlockHeight      uint64
+	ExternalNonce        uint64
+	EBalances            map[string]map[string]EBalance
 	FirstExternalAddress map[string]string
 }
 
@@ -40,4 +40,17 @@ func (eb *EBalance) UpdateBlockHeight(h uint64) {
 // UpdateNonce sets EBalance's nonce.
 func (eb *EBalance) UpdateNonce(n uint64) {
 	eb.Nonce = n
+}
+
+type OldAccount struct {
+	Nonce           uint64
+	Address         string
+	PublicKey       string
+	StateRoot       string
+	AddressHash     cmn.HexBytes
+	Balance         uint64
+	Erc20Address    string
+	LastBlockHeight uint64
+	ExternalNonce   uint64
+	EBalances       map[string]EBalance
 }


### PR DESCRIPTION
## Problem

Support multiple ebalances were merged, we need a way to migrate from old account struct to new one in syncer.

## Solution

## Testing Done and Results

## Follow-up Work Needed
