### PR TITLE
accounts: limit number of addresses per asset

### DIFF
--- a/accounts/account/service.go
+++ b/accounts/account/service.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	herdiusZeroAddress = "Hx00000000000000000000000000000000"
+	herdiusZeroAddress      = "Hx00000000000000000000000000000000"
+	numAddressPerAssetLimit = 1024
 )
 
 var cdc = amino.NewCodec()
@@ -218,4 +219,12 @@ func (s *Service) AccountExternalAddressExist() bool {
 // when lock tx type is transmitted to herdius blockchain
 func (s *Service) IsHerdiusZeroAddress() bool {
 	return s.receiverAddress == herdiusZeroAddress
+}
+
+// AccountEBalancePerAssetReachLimit reports whether an account reaches limit for number of address per asset.
+func (s *Service) AccountEBalancePerAssetReachLimit(a *protobuf.Account, assetSymbol string) bool {
+	if a != nil && a.EBalances != nil && a.EBalances[assetSymbol] != nil {
+		return len(a.EBalances[assetSymbol].Asset) >= numAddressPerAssetLimit
+	}
+	return false
 }

--- a/accounts/account/service_test.go
+++ b/accounts/account/service_test.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -141,4 +142,19 @@ func TestAccountExternalAddressExistTrue(t *testing.T) {
 	accService.SetAccount(account)
 	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A")
 	assert.False(t, accService.AccountExternalAddressExist())
+}
+
+func TestVerifyAccountEBalancesLimit(t *testing.T) {
+	eBalances := make(map[string]*protobuf.EBalanceAsset)
+	eBalances["ETH"] = &protobuf.EBalanceAsset{}
+	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
+	for i := 0; i < 1023; i++ {
+		address := fmt.Sprintf("%d", i)
+		eBalances["ETH"].Asset[address] = &protobuf.EBalance{Address: address}
+	}
+	account := &protobuf.Account{Balance: 1, EBalances: eBalances}
+	accService := NewAccountService()
+	assert.False(t, accService.AccountEBalancePerAssetReachLimit(account, "ETH"))
+	eBalances["ETH"].Asset["1024"] = nil
+	assert.True(t, accService.AccountEBalancePerAssetReachLimit(account, "ETH"))
 }

--- a/hbi/message/plugin.go
+++ b/hbi/message/plugin.go
@@ -190,6 +190,19 @@ func (state *TransactionMessagePlugin) Receive(ctx *network.PluginContext) error
 				}
 				return errors.New(failedVerificationMsg)
 			}
+			if accSrv.AccountEBalancePerAssetReachLimit(account, tx.Asset.Symbol) {
+				failedVerificationMsg := "Account reached number of addresses limit"
+				err = apiClient.Reply(network.WithSignMessage(context.Background(), true), nonce,
+					&protoplugin.TxResponse{
+						TxId: "", Status: "failed", Queued: 0, Pending: 0,
+						Message: failedVerificationMsg,
+					})
+				nonce++
+				if err != nil {
+					return fmt.Errorf(fmt.Sprintf("Failed to reply to client :%v", err))
+				}
+				return errors.New(failedVerificationMsg)
+			}
 			postAccountUpdateTx(tx, ctx, accSrv)
 			return nil
 		}


### PR DESCRIPTION
## Problem

Limit number of addresses per asset.

## Solution

Validate the limit is reached before updating account.

## Testing Done and Results

Passed.

## Follow-up Work Needed
