### PR TITLE
Fund Lock Tx Part -1

### DIFF
--- a/accounts/account/service.go
+++ b/accounts/account/service.go
@@ -217,8 +217,5 @@ func (s *Service) AccountExternalAddressExist() bool {
 // IsHerdiusZeroAddress checks if receiver address is of herdius zero address
 // when lock tx type is transmitted to herdius blockchain
 func (s *Service) IsHerdiusZeroAddress() bool {
-	if s.receiverAddress == herdiusZeroAddress {
-		return true
-	}
-	return false
+	return s.receiverAddress == herdiusZeroAddress
 }

--- a/accounts/account/service.go
+++ b/accounts/account/service.go
@@ -32,10 +32,75 @@ type ServiceI interface {
 }
 
 // Service ...
-type Service struct{}
+type Service struct {
+	account         *protobuf.Account
+	assetSymbol     string
+	address         string
+	receiverAddress string
+	extAddress      string
+	txValue         uint64
+}
 
-// TODO: Make it better so as not a
-// global variable
+// Account returns state db account
+func (s *Service) Account() *protobuf.Account {
+	return s.account
+}
+
+// SetAccount sets Service account
+func (s *Service) SetAccount(account *protobuf.Account) {
+	s.account = account
+}
+
+// AssetSymbol returns servie asset symbol
+func (s *Service) AssetSymbol() string {
+	return s.assetSymbol
+}
+
+// SetAssetSymbol sets Service asset symbol
+func (s *Service) SetAssetSymbol(assetSymbol string) {
+	s.assetSymbol = assetSymbol
+}
+
+// Address returns service her account address
+func (s *Service) Address() string {
+	return s.address
+}
+
+// SetAddress sets Service asset symbol
+func (s *Service) SetAddress(address string) {
+	s.address = address
+}
+
+// ReceiverAddress returns receiver's her account address
+func (s *Service) ReceiverAddress() string {
+	return s.receiverAddress
+}
+
+// SetReceiverAddress sets receiver's her account address
+func (s *Service) SetReceiverAddress(receiverAddress string) {
+	s.receiverAddress = receiverAddress
+}
+
+// ExtAddress returns service ExtAddress
+func (s *Service) ExtAddress() string {
+	return s.extAddress
+}
+
+// SetExtAddress sets Service ExtAddress
+func (s *Service) SetExtAddress(extAddress string) {
+	s.extAddress = extAddress
+}
+
+// TxValue returns transaction transfer value
+func (s *Service) TxValue() uint64 {
+	return s.txValue
+}
+
+// SetTxValue sets transaction transfer value
+func (s *Service) SetTxValue(txValue uint64) {
+	s.txValue = txValue
+}
+
 var (
 	_ ServiceI = (*Service)(nil)
 )
@@ -109,16 +174,16 @@ func (s *Service) GetAccountByAddress(address string) (*protobuf.Account, error)
 }
 
 // VerifyAccountBalance verifies if account has enough HER tokens or external asset balances
-func (s *Service) VerifyAccountBalance(a *protobuf.Account, txValue uint64, assetSymbol string, extAddress string) bool {
+func (s *Service) VerifyAccountBalance() bool {
 	// Get the balance of required asset
-	if strings.EqualFold(strings.ToUpper(assetSymbol), "HER") {
-		if a.Balance >= txValue {
+	if strings.EqualFold(strings.ToUpper(s.assetSymbol), "HER") {
+		if s.account.Balance >= s.txValue {
 			return true
 		}
-	} else if a != nil && len(a.EBalances) > 0 && a.EBalances[strings.ToUpper(assetSymbol)] != nil {
-		if asset := a.EBalances[strings.ToUpper(assetSymbol)].Asset; asset != nil {
-			eb, ok := asset[extAddress]
-			if ok && eb.Balance >= txValue {
+	} else if s.account != nil && len(s.account.EBalances) > 0 && s.account.EBalances[strings.ToUpper(s.assetSymbol)] != nil {
+		if asset := s.account.EBalances[strings.ToUpper(s.assetSymbol)].Asset; asset != nil {
+			eb, ok := asset[s.extAddress]
+			if ok && eb.Balance >= s.txValue {
 				return ok
 			}
 		}
@@ -139,10 +204,10 @@ func (s *Service) VerifyAccountNonce(a *protobuf.Account, txNonce uint64) bool {
 }
 
 // AccountExternalAddressExist reports whether an external address existed in EBalances
-func (s *Service) AccountExternalAddressExist(a *protobuf.Account, assetSymbol, extAddress string) bool {
-	if a != nil && a.EBalances != nil && a.EBalances[assetSymbol] != nil {
-		if asset := a.EBalances[assetSymbol].Asset; asset != nil {
-			_, ok := asset[extAddress]
+func (s *Service) AccountExternalAddressExist() bool {
+	if s.account != nil && s.account.EBalances != nil && s.account.EBalances[s.assetSymbol] != nil {
+		if asset := s.account.EBalances[s.assetSymbol].Asset; asset != nil {
+			_, ok := asset[s.extAddress]
 			return ok
 		}
 	}
@@ -151,8 +216,8 @@ func (s *Service) AccountExternalAddressExist(a *protobuf.Account, assetSymbol, 
 
 // IsHerdiusZeroAddress checks if receiver address is of herdius zero address
 // when lock tx type is transmitted to herdius blockchain
-func (s *Service) IsHerdiusZeroAddress(address string) bool {
-	if address == herdiusZeroAddress {
+func (s *Service) IsHerdiusZeroAddress() bool {
+	if s.receiverAddress == herdiusZeroAddress {
 		return true
 	}
 	return false

--- a/accounts/account/service_test.go
+++ b/accounts/account/service_test.go
@@ -12,13 +12,13 @@ import (
 func TestVerifyAccountBalanceTrue(t *testing.T) {
 	account := &protobuf.Account{Balance: 10}
 	accService := NewAccountService()
-	assert.True(t, accService.VerifyAccountBalance(account, 5, "HER"))
+	assert.True(t, accService.VerifyAccountBalance(account, 5, "HER", ""))
 }
 
 func TestVerifyAccountBalanceFalse(t *testing.T) {
 	account := &protobuf.Account{Balance: 1}
 	accService := NewAccountService()
-	assert.False(t, accService.VerifyAccountBalance(account, 5, "HER"))
+	assert.False(t, accService.VerifyAccountBalance(account, 5, "HER", ""))
 }
 
 func TestVerifyExternalAssetBalanceTrue(t *testing.T) {
@@ -32,7 +32,7 @@ func TestVerifyExternalAssetBalanceTrue(t *testing.T) {
 	eBalances["ETH"].Asset[eBalance.Address] = eBalance
 	account := &protobuf.Account{Balance: 10, EBalances: eBalances}
 	accService := NewAccountService()
-	assert.True(t, accService.VerifyAccountBalance(account, 5, "ETH"))
+	assert.True(t, accService.VerifyAccountBalance(account, 5, "ETH", eBalance.Address))
 }
 
 func TestVerifyExternalAssetBalanceFalse(t *testing.T) {
@@ -46,7 +46,7 @@ func TestVerifyExternalAssetBalanceFalse(t *testing.T) {
 	eBalances["ETH"].Asset[eBalance.Address] = eBalance
 	account := &protobuf.Account{Balance: 1, EBalances: eBalances}
 	accService := NewAccountService()
-	assert.False(t, accService.VerifyAccountBalance(account, 5, "ETH"))
+	assert.False(t, accService.VerifyAccountBalance(account, 5, "ETH", eBalance.Address))
 }
 
 func TestVerifyAccountNonceHighTrue(t *testing.T) {

--- a/accounts/account/service_test.go
+++ b/accounts/account/service_test.go
@@ -10,15 +10,21 @@ import (
 )
 
 func TestVerifyAccountBalanceTrue(t *testing.T) {
-	account := &protobuf.Account{Balance: 10}
 	accService := NewAccountService()
-	assert.True(t, accService.VerifyAccountBalance(account, 5, "HER", ""))
+	account := &protobuf.Account{Balance: 10}
+	accService.SetAccount(account)
+	accService.SetTxValue(5)
+	accService.SetAssetSymbol("HER")
+	assert.True(t, accService.VerifyAccountBalance())
 }
 
 func TestVerifyAccountBalanceFalse(t *testing.T) {
 	account := &protobuf.Account{Balance: 1}
 	accService := NewAccountService()
-	assert.False(t, accService.VerifyAccountBalance(account, 5, "HER", ""))
+	accService.SetAccount(account)
+	accService.SetTxValue(5)
+	accService.SetAssetSymbol("HER")
+	assert.False(t, accService.VerifyAccountBalance())
 }
 
 func TestVerifyExternalAssetBalanceTrue(t *testing.T) {
@@ -32,7 +38,11 @@ func TestVerifyExternalAssetBalanceTrue(t *testing.T) {
 	eBalances["ETH"].Asset[eBalance.Address] = eBalance
 	account := &protobuf.Account{Balance: 10, EBalances: eBalances}
 	accService := NewAccountService()
-	assert.True(t, accService.VerifyAccountBalance(account, 5, "ETH", eBalance.Address))
+	accService.SetAccount(account)
+	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A")
+	accService.SetTxValue(1)
+	accService.SetAssetSymbol("ETH")
+	assert.True(t, accService.VerifyAccountBalance())
 }
 
 func TestVerifyExternalAssetBalanceFalse(t *testing.T) {
@@ -46,7 +56,11 @@ func TestVerifyExternalAssetBalanceFalse(t *testing.T) {
 	eBalances["ETH"].Asset[eBalance.Address] = eBalance
 	account := &protobuf.Account{Balance: 1, EBalances: eBalances}
 	accService := NewAccountService()
-	assert.False(t, accService.VerifyAccountBalance(account, 5, "ETH", eBalance.Address))
+	accService.SetAccount(account)
+	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A")
+	accService.SetTxValue(2)
+	accService.SetAssetSymbol("ETH")
+	assert.False(t, accService.VerifyAccountBalance())
 }
 
 func TestVerifyAccountNonceHighTrue(t *testing.T) {
@@ -84,4 +98,47 @@ func TestPublicAddressCreation(t *testing.T) {
 
 	// Check and verify if herdius address starts with 'H'
 	assert.True(t, strings.HasPrefix(address, "H"))
+}
+
+func TestIsHerdiusZeroAddressFalse(t *testing.T) {
+	accService := NewAccountService()
+	accService.SetReceiverAddress("Hx-Not-Zero-Address")
+	assert.False(t, accService.IsHerdiusZeroAddress())
+}
+
+func TestIsHerdiusZeroAddressTrue(t *testing.T) {
+	accService := NewAccountService()
+	accService.SetReceiverAddress("Hx00000000000000000000000000000000")
+	assert.True(t, accService.IsHerdiusZeroAddress())
+}
+
+func TestAccountExternalAddressExistFalse(t *testing.T) {
+	accService := NewAccountService()
+	eBalance := &protobuf.EBalance{
+		Address: "0xD8f647855876549d2623f52126CE40D053a2ef6A",
+		Balance: 1,
+	}
+	eBalances := make(map[string]*protobuf.EBalanceAsset)
+	eBalances["ETH"] = &protobuf.EBalanceAsset{}
+	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
+	eBalances["ETH"].Asset[eBalance.Address] = eBalance
+	account := &protobuf.Account{Balance: 1, EBalances: eBalances}
+	accService.SetAccount(account)
+	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A-WrongOne")
+	assert.False(t, accService.AccountExternalAddressExist())
+}
+func TestAccountExternalAddressExistTrue(t *testing.T) {
+	accService := NewAccountService()
+	eBalance := &protobuf.EBalance{
+		Address: "0xD8f647855876549d2623f52126CE40D053a2ef6A",
+		Balance: 1,
+	}
+	eBalances := make(map[string]*protobuf.EBalanceAsset)
+	eBalances["ETH"] = &protobuf.EBalanceAsset{}
+	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
+	eBalances["ETH"].Asset[eBalance.Address] = eBalance
+	account := &protobuf.Account{Balance: 1, EBalances: eBalances}
+	accService.SetAccount(account)
+	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A")
+	assert.False(t, accService.AccountExternalAddressExist())
 }

--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -44,6 +44,10 @@ type SupervisorI interface {
 	ShardToValidators(*txbyte.Txs, *network.Network, []byte) error
 }
 
+const (
+	herdiusZeroAddress = "Hx00000000000000000000000000000000"
+)
+
 var (
 	_ SupervisorI = (*Supervisor)(nil)
 )
@@ -872,6 +876,17 @@ func (s *Supervisor) updateStateForTxs(txs *txbyte.Txs, stateTrie statedb.Trie) 
 					plog.Error().Msgf("Failed to encode failed tx: %v", err)
 				}
 			}
+			tx.Status = "success"
+			txbz, err = cdc.MarshalJSON(&tx)
+			(*txs)[i] = txbz
+			if err != nil {
+				log.Printf("Failed to encode failed tx: %v", err)
+				plog.Error().Msgf("Failed to encode failed tx: %v", err)
+			}
+			continue
+		} else if strings.EqualFold(tx.Type, "lock") {
+			// TODO: On completion of task https://app.asana.com/0/998359196895599/1127276530517142
+			// sender account will be updated in the state db.
 			tx.Status = "success"
 			txbz, err = cdc.MarshalJSON(&tx)
 			(*txs)[i] = txbz

--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -44,10 +44,6 @@ type SupervisorI interface {
 	ShardToValidators(*txbyte.Txs, *network.Network, []byte) error
 }
 
-const (
-	herdiusZeroAddress = "Hx00000000000000000000000000000000"
-)
-
 var (
 	_ SupervisorI = (*Supervisor)(nil)
 )

--- a/syncer/eth.go
+++ b/syncer/eth.go
@@ -107,6 +107,8 @@ func (es *EthSyncer) Update() {
 			// last-balance < External-ETH
 			// Balance of ETH in H = Balance of ETH in H + ( Current_External_Bal - last_External_Bal_In_Cache)
 			if lastExtBalance, ok := last.LastExtBalance[storageKey]; ok && lastExtBalance != nil {
+				log.Println("lastExtBalance : ", lastExtBalance)
+				log.Println("es.ExtBalance[ethAccount.Address] : ", es.ExtBalance[ethAccount.Address])
 				if lastExtBalance.Cmp(es.ExtBalance[ethAccount.Address]) < 0 {
 					log.Printf("lastExtBalance.Cmp(es.ExtBalance[%s])", ethAccount.Address)
 

--- a/syncer/eth.go
+++ b/syncer/eth.go
@@ -107,8 +107,6 @@ func (es *EthSyncer) Update() {
 			// last-balance < External-ETH
 			// Balance of ETH in H = Balance of ETH in H + ( Current_External_Bal - last_External_Bal_In_Cache)
 			if lastExtBalance, ok := last.LastExtBalance[storageKey]; ok && lastExtBalance != nil {
-				log.Println("lastExtBalance : ", lastExtBalance)
-				log.Println("es.ExtBalance[ethAccount.Address] : ", es.ExtBalance[ethAccount.Address])
 				if lastExtBalance.Cmp(es.ExtBalance[ethAccount.Address]) < 0 {
 					log.Printf("lastExtBalance.Cmp(es.ExtBalance[%s])", ethAccount.Address)
 


### PR DESCRIPTION
## Problem

As a part of DeFi phase 1, we need a transaction that will lock external assets such as BTC, ETH etc and mint Herdius specific external assets such as hBTC, hETH etc. This transaction should be of type **lock**. This locking transaction will have Herdius Zero Address in the ReceiverAddress field **Hx00000000000000000000000000000000**.



Asana Link: 
[Modify Tx struct for DeFi - Part 1](https://app.asana.com/0/998359196895599/1127276530517142)
## Solution
Right now it has implemented the below validations:
1. Sender should have enough balance in the external asset address
2. Sender should provide correct Herdius Zero Address.
3. External Address should exist.

Along with the above, right now **lock**, transactions are successfully getting processed. However, account update in state db is yet to be completed since it has a dependency to this task [Modifying Account struct](https://app.asana.com/0/998359196895599/1127276530517142)

## Testing Done and Results

**Validations**
1. Sender should have enough balance in the external asset address

lingrajs-MacBook-Air:herdius-blockchain-api lingrajmahanand$ go run client.go -txtype=lock
2019/06/19 17:00:20 endpoint: http://localhost:80/tx
2019/06/19 17:00:20 Fund lock transaction : HKTXmdsHyZn1B2ErRKiG4iN34YixCgdQgx
2019/06/19 17:00:20 
2019/06/19 17:00:20 txResponse : {TxId: Pending:0 Queued:0 Status:failed Message:Not enough balance: 2099370000000000000 XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} 

2. Sender should provide correct Herdius Zero Address.

lingrajs-MacBook-Air:herdius-blockchain-api lingrajmahanand$ go run client.go -txtype=lock
2019/06/19 17:02:04 endpoint: http://localhost:80/tx
2019/06/19 17:02:04 Fund lock transaction : HKTXmdsHyZn1B2ErRKiG4iN34YixCgdQgx
2019/06/19 17:02:04 
2019/06/19 17:02:04 txResponse : {TxId: Pending:0 Queued:0 Status:failed Message:Incorrect herdius zero address: Hx XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} 

3. External Address should exist.

lingrajs-MacBook-Air:herdius-blockchain-api lingrajmahanand$ go run client.go -txtype=lock
2019/06/19 17:03:18 endpoint: http://localhost:80/tx
2019/06/19 17:03:18 Fund lock transaction : HKTXmdsHyZn1B2ErRKiG4iN34YixCgdQgx
2019/06/19 17:03:18 
2019/06/19 17:03:18 txResponse : {TxId: Pending:0 Queued:0 Status:failed Message:External address does not exist: 0x9aA7E9819D781eFf5B239b572c4Fe8F964a899c XXX_NoUnkeyedLiteral:{} XXX_unrecognized:[] XXX_sizecache:0} 

Transaction is getting successfully submitted for locking of the fund at the moment. But locking of fund needs the accounts to be updated in state db and it will be taken care of in a separate task.

## Follow-up Work Needed

Follow up task would be to update the state db once this task  [Modifying Account struct](https://app.asana.com/0/998359196895599/1127276530517142) is completed.