### PR TITLE
accounts: verify external balance with current lock amount

### DIFF
--- a/accounts/account/service_test.go
+++ b/accounts/account/service_test.go
@@ -183,6 +183,36 @@ func TestVerifyLockedAmount(t *testing.T) {
 	assert.False(t, accService.VerifyLockedAmount())
 }
 
+func TestVerifyAccountBalanceWithLockAmount(t *testing.T) {
+	accService := NewAccountService()
+	symbol := "ETH"
+	extAddr := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
+	eBalance := &protobuf.EBalance{
+		Address: extAddr,
+		Balance: 1,
+	}
+	eBalances := make(map[string]*protobuf.EBalanceAsset)
+	eBalances[symbol] = &protobuf.EBalanceAsset{}
+	eBalances[symbol].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[symbol].Asset[eBalance.Address] = eBalance
+
+	lockedBalances := make(map[string]*protobuf.LockBalanceAsset)
+	lockedBalances[symbol] = &protobuf.LockBalanceAsset{}
+	lockedBalances[symbol].Asset = make(map[string]uint64)
+	lockedBalances[symbol].Asset[extAddr] = 0
+
+	account := &protobuf.Account{Balance: 1, EBalances: eBalances, LockBalances: lockedBalances}
+	accService.SetAccount(account)
+	accService.SetExtAddress(extAddr)
+	accService.SetAssetSymbol(symbol)
+	accService.SetTxValue(1)
+	assert.True(t, accService.VerifyAccountBalance())
+	lockedBalances[symbol].Asset[extAddr] = 1
+	assert.False(t, accService.VerifyAccountBalance())
+	lockedBalances[symbol].Asset[extAddr] = 2
+	assert.False(t, accService.VerifyAccountBalance())
+}
+
 func TestVerifyRedeemAmount(t *testing.T) {
 	accService := NewAccountService()
 	symbol := "ETH"


### PR DESCRIPTION
## Problem

Normal TX for external balance needs verification for locked amount.

Asana Link: https://app.asana.com/0/1125705697210963/1127276530517143

## Solution

Add verification base on current account locked balance. The current external balance must be greater than corresponding locked amount.

## Testing Done and Results

Passed.

## Follow-up Work Needed
