### PR TITLE
Fix/mp remove txs called twice

### DIFF
--- a/storage/mempool/mempool.go
+++ b/storage/mempool/mempool.go
@@ -101,7 +101,6 @@ func (m *MemPool) processQueue(accountService account.ServiceI) {
 // GetTxs gets all transactions from the MemPool
 func (m *MemPool) GetTxs() *tx.Txs {
 	accSrv := account.NewAccountService()
-	m.processQueue(accSrv)
 	txs := &tx.Txs{}
 	m.processQueue(accSrv)
 	var cdc = amino.NewCodec()

--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -474,8 +474,6 @@ func (s *Supervisor) createSingularBlock(lastBlock *protobuf.BaseBlock, net *net
 	}
 	s.writerMutex.Unlock()
 
-	// Remove processed transactions from Memory Pool
-	mp.RemoveTxs(len(txs))
 	return baseBlock, nil
 }
 


### PR DESCRIPTION
## Problem

Duplicated calling causing noisy log lines.

## Solution

Remove them.

## Testing Done and Results

Passed.

## Follow-up Work Needed
