### PR TITLE
supervisor/service: get pool txs when wake up

### DIFF
--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -392,10 +392,9 @@ func (s *Supervisor) CreateChildBlock(net *network.Network, txs *transaction.TxL
 // or to be included in Singular base block
 func (s *Supervisor) ProcessTxs(lastBlock *protobuf.BaseBlock, net *network.Network) (*protobuf.BaseBlock, error) {
 	mp := mempool.GetMemPool()
-	txs := mp.GetTxs()
-
 	select {
 	case <-time.After(time.Duration(s.waitTime) * time.Second):
+		txs := mp.GetTxs()
 		if len(s.Validator) <= 0 || len(*txs) <= 0 {
 			log.Printf("Block creation wait time (%d) elapsed, creating singular base block but with %v transactions", s.waitTime, len(*txs))
 			baseBlock, err := s.createSingularBlock(lastBlock, net, *txs, mp, s.stateRoot)


### PR DESCRIPTION
When supervisor processes pool txs, it get all txs in pool before going
to sleep. This behavior causes delay time for all pending txs which come
in to the pool at the time supervisor sleep.

Get the txs when supervisor wakes up, we will reduce the delay time of
pending txs.

## Problem

Asana Link: https://app.asana.com/0/1125705697210963/1130368524675779

## Solution

## Testing Done and Results

Passed.

## Follow-up Work Needed
