### PR TITLE
Locked amount and Redeem amount also need to be added in Signature

### DIFF
--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -761,6 +761,8 @@ func (s *Supervisor) updateStateForTxs(txs *txbyte.Txs, stateTrie statedb.Trie) 
 			Fee:                   tx.Asset.Fee,
 			Nonce:                 tx.Asset.Nonce,
 			ExternalSenderAddress: tx.Asset.ExternalSenderAddress,
+			LockedAmount:          tx.Asset.LockedAmount,
+			RedeemedAmount:        tx.Asset.RedeemedAmount,
 		}
 		verifiableTx := pluginproto.Tx{
 			SenderAddress:   tx.SenderAddress,


### PR DESCRIPTION
## Problem
Locked amount and redeem amount are also need to be added in signature verification. They were being processed without having them included in the signature verification part.
Asana Link: 

## Solution
Included both Locked amount and redeem amount in signature verification process.

## Testing Done and Results
All test cases were passed.

## Follow-up Work Needed
