### PR TITLE
Fix FirstExternalAddress, and tests

### DIFF
--- a/accounts/account/service.go
+++ b/accounts/account/service.go
@@ -193,16 +193,17 @@ func (s *Service) GetAccountByAddress(address string) (*protobuf.Account, error)
 	}
 
 	acc := &protobuf.Account{
-		PublicKey:       account.PublicKey,
-		Address:         account.Address,
-		Nonce:           account.Nonce,
-		Balance:         account.Balance,
-		StorageRoot:     stateRootHex.String(),
-		EBalances:       eBalances,
-		LockBalances:    lockBalances,
-		Erc20Address:    account.Erc20Address,
-		ExternalNonce:   account.ExternalNonce,
-		LastBlockHeight: account.LastBlockHeight,
+		PublicKey:            account.PublicKey,
+		Address:              account.Address,
+		Nonce:                account.Nonce,
+		Balance:              account.Balance,
+		StorageRoot:          stateRootHex.String(),
+		EBalances:            eBalances,
+		LockBalances:         lockBalances,
+		Erc20Address:         account.Erc20Address,
+		ExternalNonce:        account.ExternalNonce,
+		LastBlockHeight:      account.LastBlockHeight,
+		FirstExternalAddress: account.FirstExternalAddress,
 	}
 	return acc, nil
 }

--- a/supervisor/service/service_test.go
+++ b/supervisor/service/service_test.go
@@ -160,6 +160,7 @@ func TestUpdateExternalAccountBalance(t *testing.T) {
 	assert.True(t, len(account.EBalances) > 0)
 	assert.Equal(t, extSenderAddress, account.FirstExternalAddress[symbol])
 	assert.Equal(t, tx.Asset.ExternalSenderAddress, account.EBalances[symbol][extSenderAddress].Address)
+	assert.Equal(t, tx.Asset.ExternalSenderAddress, account.FirstExternalAddress[symbol])
 
 	asset = &pluginproto.Asset{
 		Symbol:                symbol,
@@ -178,6 +179,8 @@ func TestUpdateExternalAccountBalance(t *testing.T) {
 	assert.True(t, len(account.EBalances) > 0)
 	assert.Equal(t, tx.Asset.ExternalSenderAddress, account.EBalances[symbol][extSenderAddress].Address)
 	assert.Equal(t, uint64(0), account.EBalances[symbol][extSenderAddress].Balance)
+	assert.Equal(t, tx.Asset.ExternalSenderAddress, account.FirstExternalAddress[symbol])
+
 }
 
 func TestIsExternalAssetAddressExistTrue(t *testing.T) {


### PR DESCRIPTION
## Problem

Asana Link: 

## Solution
Update FirstExternalAddress in Account return struct

## Testing Done and Results
updated tests 

curl http://localhost/account/HQjErP6tF4eE3uMeM7aKPv1eL3eomgDZsw
{"nonce":1,"address":"HQjErP6tF4eE3uMeM7aKPv1eL3eomgDZsw","balance":0,"storageRoot":"36353690D649392595C27F09AEE917B0E43716A311D5BF4E1ACD4D1B9D1CC96B","publicKey":"Ag7MhbMgltL6VnO5VNvwcAzK98P9U6UKpIPnM7hr8k8B","erc20Address":"","FirstExternalAddress":{"ETH":"0xD8f647855876549d2623f52126CE40D053a2ef6A"},"ExternalNonce":0,"LastBlockHeight":0,"EBalances":{"ETH":{"0xD8f647855876549d2623f52126CE40D053a2ef6A":{"Address":"0xD8f647855876549d2623f52126CE40D053a2ef6A","Balance":2673600066400000000,"LastBlockHeight":5998703,"Nonce":238}}}}

## Follow-up Work Needed
