### PR TITLE
syncer: fix wrong wait group initialization

### DIFF
--- a/syncer/account.go
+++ b/syncer/account.go
@@ -53,7 +53,7 @@ func sync(exBal external.BalanceStorage, rpc apiEndponts) {
 	it := ethtrie.NewIterator(stateTrie.NodeIterator(nil))
 
 	log.Println("Sync account start")
-	var wg *stdSync.WaitGroup
+	var wg stdSync.WaitGroup
 	for it.Next() {
 		var senderAccount statedb.Account
 		senderAddressBytes := it.Key


### PR DESCRIPTION
## Problem

Asana Link: https://app.asana.com/0/1125705697210963/1131414887961703

## Solution

## Testing Done and Results

## Follow-up Work Needed
