### PR TITLE
Locked amount fix

### DIFF
--- a/accounts/account/service.go
+++ b/accounts/account/service.go
@@ -282,9 +282,9 @@ func (s *Service) VerifyLockedAmount() bool {
 // VerifyRedeemAmount checks account have proper locked amount for redeeming
 func (s *Service) VerifyRedeemAmount() bool {
 	log.Printf("Account before Redeem: %+v", s.account)
-	if s.account != nil && s.account.EBalances != nil && s.account.EBalances[s.assetSymbol] != nil {
-		if asset := s.account.EBalances[s.assetSymbol].Asset; asset != nil {
-			return s.txLockedAmount <= asset[s.account.FirstExternalAddress["ETH"]].Balance
+	if s.account != nil && s.account.LockBalances != nil && s.account.LockBalances[s.assetSymbol] != nil {
+		if asset := s.account.LockBalances[s.assetSymbol].Asset; asset != nil {
+			return s.txRedeemAmount <= asset[s.extAddress]
 		}
 	}
 	return false

--- a/accounts/account/service.go
+++ b/accounts/account/service.go
@@ -282,9 +282,9 @@ func (s *Service) VerifyLockedAmount() bool {
 // VerifyRedeemAmount checks account have proper locked amount for redeeming
 func (s *Service) VerifyRedeemAmount() bool {
 	log.Printf("Account before Redeem: %+v", s.account)
-	if s.account != nil && s.account.LockBalances != nil && s.account.LockBalances[s.assetSymbol] != nil {
-		if asset := s.account.LockBalances[s.assetSymbol].Asset; asset != nil {
-			return s.txRedeemAmount <= asset[s.extAddress]
+	if s.account != nil && s.account.EBalances != nil && s.account.EBalances[s.assetSymbol] != nil {
+		if asset := s.account.EBalances[s.assetSymbol].Asset; asset != nil {
+			return s.txLockedAmount <= asset[s.account.FirstExternalAddress["ETH"]].Balance
 		}
 	}
 	return false

--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -563,7 +563,7 @@ func updateAccountLockedBalance(senderAccount *statedb.Account, tx *pluginproto.
 		senderAccount.LockedBalance[asset] = make(map[string]uint64)
 	}
 	if tx.SenderAddress == senderAccount.Address {
-		senderAccount.LockedBalance[asset][tx.Asset.ExternalSenderAddress] += tx.Asset.Value
+		senderAccount.LockedBalance[asset][tx.Asset.ExternalSenderAddress] += tx.Asset.LockedAmount
 	}
 	withdraw(senderAccount, tx.Asset.Symbol, tx.Asset.ExternalSenderAddress, tx.Asset.LockedAmount)
 	senderAccount.Nonce = tx.Asset.Nonce

--- a/supervisor/service/service_test.go
+++ b/supervisor/service/service_test.go
@@ -433,7 +433,7 @@ func TestUpdateAccountLockedBalance(t *testing.T) {
 		ExternalSenderAddress: extSenderAddress,
 		Nonce:                 1,
 		Network:               "Herdius",
-		Value:                 lockedAmount,
+		LockedAmount:          lockedAmount,
 	}
 	tx := &pluginproto.Tx{
 		SenderAddress: "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
@@ -469,7 +469,7 @@ func TestUpdateRedeemAccountLockedBalance(t *testing.T) {
 		ExternalSenderAddress: extSenderAddress,
 		Nonce:                 1,
 		Network:               "Herdius",
-		Value:                 lockedAmount,
+		LockedAmount:          lockedAmount,
 	}
 	tx := &pluginproto.Tx{
 		SenderAddress: "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",


### PR DESCRIPTION
## Problem
We send a locked tx then locked balances are getting updated with tx value rather than locked amount.
Asana Link: 

## Solution
Correct it to add locked amount.
Fixed the test case `TestUpdateAccountLockedBalance `
## Testing Done and Results
Local testing and passed test cases.
## Follow-up Work Needed
