### PR TITLE
decouple builder from config

### DIFF
--- a/cmd/herserver/main.go
+++ b/cmd/herserver/main.go
@@ -281,7 +281,9 @@ func main() {
 	opcode.RegisterMessageType(types.OpcodeTxsByBlockHeightRequest, &protoplugin.TxsByBlockHeightRequest{})
 	opcode.RegisterMessageType(types.OpcodeLastBlockRequest, &protoplugin.LastBlockRequest{})
 
-	builder := network.NewBuilder(env)
+	config := config.GetConfiguration(env)
+	address := config.ConstructTCPAddress()
+	builder := network.NewBuilderWithOptions(network.Address(address))
 	builder.SetKeys(keys)
 
 	builder.SetAddress(network.FormatAddress(confg.Protocol, confg.SelfBroadcastIP, uint16(port)))

--- a/p2p/network/backoff/plugin_test.go
+++ b/p2p/network/backoff/plugin_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/herdius/herdius-core/config"
 	"github.com/herdius/herdius-core/p2p/crypto"
 	"github.com/herdius/herdius-core/p2p/crypto/ed25519"
 	"github.com/herdius/herdius-core/p2p/network"
@@ -86,7 +87,10 @@ func newNode(i int, addDiscoveryPlugin bool, addBackoffPlugin bool) (*network.Ne
 		keys[addr] = ed25519.RandomKeyPair()
 	}
 
-	builder := network.NewBuilder("dev")
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+
+	builder := network.NewBuilder(address)
 	builder.SetKeys(keys[addr])
 	builder.SetAddress(addr)
 

--- a/p2p/network/backoff/plugin_test.go
+++ b/p2p/network/backoff/plugin_test.go
@@ -90,7 +90,7 @@ func newNode(i int, addDiscoveryPlugin bool, addBackoffPlugin bool) (*network.Ne
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
 
-	builder := network.NewBuilder(address)
+	builder := network.NewBuilderWithOptions(network.Address(address))
 	builder.SetKeys(keys[addr])
 	builder.SetAddress(addr)
 

--- a/p2p/network/builder.go
+++ b/p2p/network/builder.go
@@ -53,6 +53,7 @@ var defaultBuilderOptions = options{
 	writeBufferSize:   defaultWriteBufferSize,
 	writeFlushLatency: defaultWriteFlushLatency,
 	writeTimeout:      defaultWriteTimeout,
+	address:           defaultaddress,
 }
 
 // A BuilderOption sets options such as connection timeout and cryptographic // policies for the network
@@ -63,6 +64,13 @@ type BuilderOption func(*options)
 func ConnectionTimeout(d time.Duration) BuilderOption {
 	return func(o *options) {
 		o.connectionTimeout = d
+	}
+}
+
+//Address address sets assress for connectionn, should include type and port tcp://127.0.0.1:port
+func Address(address string) BuilderOption {
+	return func(o *options) {
+		o.address = address
 	}
 }
 
@@ -123,10 +131,10 @@ func WriteTimeout(d time.Duration) BuilderOption {
 }
 
 // NewBuilder returns a new builder with default options.
-func NewBuilder(fullTCPAddress string) *Builder {
+func NewBuilder() *Builder {
 	builder := &Builder{
 		opts:       defaultBuilderOptions,
-		address:    fullTCPAddress,
+		address:    defaultaddress,
 		keys:       ed25519.RandomKeyPair(),
 		transports: new(sync.Map),
 	}
@@ -139,8 +147,8 @@ func NewBuilder(fullTCPAddress string) *Builder {
 }
 
 // NewBuilderWithOptions returns a new builder with specified options.
-func NewBuilderWithOptions(fullTCPAddress string, opt ...BuilderOption) *Builder {
-	builder := NewBuilder(fullTCPAddress)
+func NewBuilderWithOptions(opt ...BuilderOption) *Builder {
+	builder := NewBuilder()
 
 	for _, o := range opt {
 		o(&builder.opts)

--- a/p2p/network/builder.go
+++ b/p2p/network/builder.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/herdius/herdius-core/config"
 	"github.com/herdius/herdius-core/p2p/crypto"
 	"github.com/herdius/herdius-core/p2p/crypto/blake2b"
 	"github.com/herdius/herdius-core/p2p/crypto/ed25519"
@@ -124,12 +123,10 @@ func WriteTimeout(d time.Duration) BuilderOption {
 }
 
 // NewBuilder returns a new builder with default options.
-func NewBuilder(env string) *Builder {
-	config := config.GetConfiguration(env)
-	address := config.ConstructTCPAddress()
+func NewBuilder(fullTCPAddress string) *Builder {
 	builder := &Builder{
 		opts:       defaultBuilderOptions,
-		address:    address,
+		address:    fullTCPAddress,
 		keys:       ed25519.RandomKeyPair(),
 		transports: new(sync.Map),
 	}
@@ -142,8 +139,8 @@ func NewBuilder(env string) *Builder {
 }
 
 // NewBuilderWithOptions returns a new builder with specified options.
-func NewBuilderWithOptions(env string, opt ...BuilderOption) *Builder {
-	builder := NewBuilder(env)
+func NewBuilderWithOptions(fullTCPAddress string, opt ...BuilderOption) *Builder {
+	builder := NewBuilder(fullTCPAddress)
 
 	for _, o := range opt {
 		o(&builder.opts)

--- a/p2p/network/builder_test.go
+++ b/p2p/network/builder_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/herdius/herdius-core/config"
 	"github.com/herdius/herdius-core/p2p/crypto/blake2b"
 	"github.com/herdius/herdius-core/p2p/crypto/ed25519"
 	"github.com/pkg/errors"
@@ -88,7 +89,10 @@ func TestBuilderAddress(t *testing.T) {
 func TestDuplicatePlugin(t *testing.T) {
 	t.Parallel()
 
-	builder := NewBuilder("dev")
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+
+	builder := NewBuilder(address)
 	_, err := builder.Build()
 
 	assert.Equal(t, nil, err)
@@ -105,7 +109,9 @@ func TestConnectionTimeout(t *testing.T) {
 	t.Parallel()
 
 	timeout := 5 * time.Second
-	builder := NewBuilderWithOptions("dev", ConnectionTimeout(timeout))
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+	builder := NewBuilderWithOptions(address, ConnectionTimeout(timeout))
 	net, err := builder.Build()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, net.opts.connectionTimeout, timeout, "connection timeout given should match found")
@@ -115,7 +121,9 @@ func TestSignaturePolicy(t *testing.T) {
 	t.Parallel()
 
 	signaturePolicy := ed25519.New()
-	builder := NewBuilderWithOptions("dev", SignaturePolicy(signaturePolicy))
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+	builder := NewBuilderWithOptions(address, SignaturePolicy(signaturePolicy))
 	net, err := builder.Build()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, net.opts.signaturePolicy, signaturePolicy, "signature policy given should match found")
@@ -125,7 +133,9 @@ func TestHashPolicy(t *testing.T) {
 	t.Parallel()
 
 	hashPolicy := blake2b.New()
-	builder := NewBuilderWithOptions("dev", HashPolicy(hashPolicy))
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+	builder := NewBuilderWithOptions(address, HashPolicy(hashPolicy))
 	net, err := builder.Build()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, net.opts.hashPolicy, hashPolicy, "hash policy given should match found")
@@ -136,8 +146,10 @@ func TestWindowSize(t *testing.T) {
 
 	recvWindowSize := 2000
 	sendWindowSize := 1000
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
 	builder := NewBuilderWithOptions(
-		"dev",
+		address,
 		RecvWindowSize(recvWindowSize),
 		SendWindowSize(sendWindowSize),
 	)
@@ -153,8 +165,10 @@ func TestWriteBufferSize(t *testing.T) {
 	t.Parallel()
 
 	writeBufferSize := 2048
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
 	builder := NewBuilderWithOptions(
-		"dev",
+		address,
 		WriteBufferSize(writeBufferSize),
 	)
 	net, err := builder.Build()
@@ -166,8 +180,10 @@ func TestWriteFlushLatency(t *testing.T) {
 	t.Parallel()
 
 	writeFlushLatency := 100 * time.Millisecond
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
 	builder := NewBuilderWithOptions(
-		"dev",
+		address,
 		WriteFlushLatency(writeFlushLatency),
 	)
 	net, err := builder.Build()
@@ -179,8 +195,10 @@ func TestWriteTimeout(t *testing.T) {
 	t.Parallel()
 
 	writeTimeout := 1 * time.Second
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
 	builder := NewBuilderWithOptions(
-		"dev",
+		address,
 		WriteTimeout(writeTimeout),
 	)
 	net, err := builder.Build()

--- a/p2p/network/builder_test.go
+++ b/p2p/network/builder_test.go
@@ -21,7 +21,9 @@ var (
 )
 
 func buildNetwork(port uint16) (*Network, error) {
-	builder := NewBuilder("dev")
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+	builder := NewBuilderWithOptions(Address(address))
 	builder.SetKeys(keys)
 	builder.SetAddress(
 		fmt.Sprintf("%s://%s:%d", protocol, host, port),
@@ -62,7 +64,9 @@ func TestSetters(t *testing.T) {
 func TestNoKeys(t *testing.T) {
 	t.Parallel()
 
-	builder := NewBuilder("dev")
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+	builder := NewBuilderWithOptions(Address(address))
 	builder.SetKeys(nil)
 	_, err := builder.Build()
 	if err == nil {
@@ -73,7 +77,9 @@ func TestNoKeys(t *testing.T) {
 func TestBuilderAddress(t *testing.T) {
 	t.Parallel()
 
-	builder := NewBuilder("dev")
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+	builder := NewBuilderWithOptions(Address(address))
 	builder.SetAddress("")
 	_, err := builder.Build()
 	assert.NotEqual(t, nil, err)
@@ -91,8 +97,7 @@ func TestDuplicatePlugin(t *testing.T) {
 
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
-
-	builder := NewBuilder(address)
+	builder := NewBuilderWithOptions(Address(address))
 	_, err := builder.Build()
 
 	assert.Equal(t, nil, err)
@@ -111,7 +116,7 @@ func TestConnectionTimeout(t *testing.T) {
 	timeout := 5 * time.Second
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
-	builder := NewBuilderWithOptions(address, ConnectionTimeout(timeout))
+	builder := NewBuilderWithOptions(Address(address), ConnectionTimeout(timeout))
 	net, err := builder.Build()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, net.opts.connectionTimeout, timeout, "connection timeout given should match found")
@@ -123,7 +128,7 @@ func TestSignaturePolicy(t *testing.T) {
 	signaturePolicy := ed25519.New()
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
-	builder := NewBuilderWithOptions(address, SignaturePolicy(signaturePolicy))
+	builder := NewBuilderWithOptions(Address(address), SignaturePolicy(signaturePolicy))
 	net, err := builder.Build()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, net.opts.signaturePolicy, signaturePolicy, "signature policy given should match found")
@@ -135,7 +140,7 @@ func TestHashPolicy(t *testing.T) {
 	hashPolicy := blake2b.New()
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
-	builder := NewBuilderWithOptions(address, HashPolicy(hashPolicy))
+	builder := NewBuilderWithOptions(Address(address), HashPolicy(hashPolicy))
 	net, err := builder.Build()
 	assert.Equal(t, nil, err)
 	assert.Equal(t, net.opts.hashPolicy, hashPolicy, "hash policy given should match found")
@@ -149,7 +154,7 @@ func TestWindowSize(t *testing.T) {
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
 	builder := NewBuilderWithOptions(
-		address,
+		Address(address),
 		RecvWindowSize(recvWindowSize),
 		SendWindowSize(sendWindowSize),
 	)
@@ -168,7 +173,7 @@ func TestWriteBufferSize(t *testing.T) {
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
 	builder := NewBuilderWithOptions(
-		address,
+		Address(address),
 		WriteBufferSize(writeBufferSize),
 	)
 	net, err := builder.Build()
@@ -183,7 +188,7 @@ func TestWriteFlushLatency(t *testing.T) {
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
 	builder := NewBuilderWithOptions(
-		address,
+		Address(address),
 		WriteFlushLatency(writeFlushLatency),
 	)
 	net, err := builder.Build()
@@ -198,7 +203,7 @@ func TestWriteTimeout(t *testing.T) {
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
 	builder := NewBuilderWithOptions(
-		address,
+		Address(address),
 		WriteTimeout(writeTimeout),
 	)
 	net, err := builder.Build()

--- a/p2p/network/network.go
+++ b/p2p/network/network.go
@@ -31,6 +31,7 @@ const (
 	defaultWriteBufferSize   = 4096
 	defaultWriteFlushLatency = 50 * time.Millisecond
 	defaultWriteTimeout      = 3 * time.Second
+	defaultaddress           = "tcp://127.0.0.1:2001"
 )
 
 var contextPool = sync.Pool{
@@ -89,6 +90,7 @@ type options struct {
 	writeBufferSize   int
 	writeFlushLatency time.Duration
 	writeTimeout      time.Duration
+	address           string
 }
 
 // ConnState represents a connection.

--- a/p2p/network/network_utils_test.go
+++ b/p2p/network/network_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/herdius/herdius-core/config"
 	"github.com/herdius/herdius-core/p2p/crypto"
 	"github.com/herdius/herdius-core/p2p/crypto/blake2b"
 	"github.com/herdius/herdius-core/p2p/crypto/ed25519"
@@ -54,7 +55,9 @@ func newTest(t *testing.T, e env, opts ...network.BuilderOption) *testSuite {
 
 func (te *testSuite) startBoostrap(numNodes int, plugins ...network.PluginInterface) {
 	for i := 0; i < numNodes; i++ {
-		builder := network.NewBuilderWithOptions("dev", te.builderOptions...)
+		config := config.GetConfiguration("dev")
+		address := config.ConstructTCPAddress()
+		builder := network.NewBuilderWithOptions(address, te.builderOptions...)
 		builder.SetKeys(te.e.signature.RandomKeyPair())
 		builder.SetAddress(network.FormatAddress(te.e.networkType, "localhost", uint16(network.GetRandomUnusedPort())))
 

--- a/p2p/network/network_utils_test.go
+++ b/p2p/network/network_utils_test.go
@@ -57,7 +57,8 @@ func (te *testSuite) startBoostrap(numNodes int, plugins ...network.PluginInterf
 	for i := 0; i < numNodes; i++ {
 		config := config.GetConfiguration("dev")
 		address := config.ConstructTCPAddress()
-		builder := network.NewBuilderWithOptions(address, te.builderOptions...)
+		te.builderOptions = append(te.builderOptions, network.Address(address))
+		builder := network.NewBuilderWithOptions(te.builderOptions...)
 		builder.SetKeys(te.e.signature.RandomKeyPair())
 		builder.SetAddress(network.FormatAddress(te.e.networkType, "localhost", uint16(network.GetRandomUnusedPort())))
 

--- a/p2p/network/plugin_test.go
+++ b/p2p/network/plugin_test.go
@@ -50,7 +50,7 @@ func TestPluginHooks(t *testing.T) {
 	for i := 0; i < nodeCount; i++ {
 		config := config.GetConfiguration("dev")
 		address := config.ConstructTCPAddress()
-		builder := NewBuilder(address)
+		builder := NewBuilderWithOptions(Address(address))
 		builder.SetKeys(ed25519.RandomKeyPair())
 		builder.SetAddress(FormatAddress("tcp", host, uint16(GetRandomUnusedPort())))
 		builder.AddPlugin(new(MockPlugin))
@@ -111,7 +111,7 @@ func TestRegisterPlugin(t *testing.T) {
 
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
-	b := NewBuilder(address)
+	b := NewBuilderWithOptions(Address(address))
 	b.AddPluginWithPriority(-99999, new(Plugin))
 
 	n, err := b.Build()

--- a/p2p/network/plugin_test.go
+++ b/p2p/network/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/herdius/herdius-core/config"
 	"github.com/herdius/herdius-core/p2p/crypto/ed25519"
 	"github.com/stretchr/testify/assert"
 
@@ -47,7 +48,9 @@ func TestPluginHooks(t *testing.T) {
 	nodeCount := 4
 
 	for i := 0; i < nodeCount; i++ {
-		builder := NewBuilder("dev")
+		config := config.GetConfiguration("dev")
+		address := config.ConstructTCPAddress()
+		builder := NewBuilder(address)
 		builder.SetKeys(ed25519.RandomKeyPair())
 		builder.SetAddress(FormatAddress("tcp", host, uint16(GetRandomUnusedPort())))
 		builder.AddPlugin(new(MockPlugin))
@@ -106,7 +109,9 @@ func TestRegisterPlugin(t *testing.T) {
 
 	PluginID := (*Plugin)(nil)
 
-	b := NewBuilder("dev")
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+	b := NewBuilder(address)
 	b.AddPluginWithPriority(-99999, new(Plugin))
 
 	n, err := b.Build()

--- a/validator/service/service_test.go
+++ b/validator/service/service_test.go
@@ -26,7 +26,7 @@ func TestCreateAndVerifyVote(t *testing.T) {
 	config := config.GetConfiguration("dev")
 	address := config.ConstructTCPAddress()
 
-	builder := network.NewBuilder(address)
+	builder := network.NewBuilderWithOptions(network.Address(address))
 	builder.SetKeys(keys)
 
 	net, err := builder.Build()

--- a/validator/service/service_test.go
+++ b/validator/service/service_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/herdius/herdius-core/blockchain/protobuf"
+	"github.com/herdius/herdius-core/config"
 	"github.com/herdius/herdius-core/crypto/secp256k1"
 	"github.com/herdius/herdius-core/p2p/crypto"
 	"github.com/herdius/herdius-core/p2p/network"
@@ -22,7 +23,10 @@ func TestCreateAndVerifyVote(t *testing.T) {
 		PubKey:     pubKey,
 	}
 
-	builder := network.NewBuilder("dev")
+	config := config.GetConfiguration("dev")
+	address := config.ConstructTCPAddress()
+
+	builder := network.NewBuilder(address)
 	builder.SetKeys(keys)
 
 	net, err := builder.Build()


### PR DESCRIPTION
## Problem

As we are separting out P2P connection, netork builder should take address as value instead of specific config

## Solution

## Testing Done and Results

updated test cases

## Follow-up Work Needed
