### PR TITLE
supervisor/service: fix wrong validators allocation

### DIFF
--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -680,7 +680,7 @@ func (s *Supervisor) validatorGroups(numGroup int) [][]string {
 	defer s.writerMutex.Unlock()
 
 	numValds := len(s.Validator)
-	validators := make([]string, len(s.Validator))
+	validators := make([]string, 0)
 	for address := range s.Validator {
 		validators = append(validators, address)
 	}
@@ -729,7 +729,7 @@ func (s *Supervisor) ShardToValidators(txs *txbyte.Txs, net *network.Network, st
 	// TODO: Make number of groups configurable.
 	numGroup := 5
 	vGroups := s.validatorGroups(numGroup)
-	fmt.Printf("Number of txs (%v), child blocks (%v), validators (%v)\n", numTxs, vGroups, numValds)
+	fmt.Printf("Number of txs (%v), groups (%v), validators (%v)\n", numTxs, vGroups, numValds)
 
 	if len(stateRoot) == 0 {
 		return fmt.Errorf("cannot process an empty stateRoot for the trie")


### PR DESCRIPTION
When calculating validators slice in groupValidators, we ended up making
the validators slice contains empty string, due to:

	make([]string, len(s.Validator))

It causes the slice contains len(s.Validator) empty string "". That code
still pass test, because we only care about the number of validator in
each group. So empty string appears as a valid element.

Just start the slice which cap 0 fix the issue.

	make([]string, 0)

## Problem

Discover the bug while doing asana Link: https://app.asana.com/0/1125705697210963/1114615936199215

## Solution

Create the validators slice with cap 0.

## Testing Done and Results

Passed.

## Follow-up Work Needed
