### PR TITLE
Removed Redeem balance verification

### DIFF
--- a/hbi/message/plugin.go
+++ b/hbi/message/plugin.go
@@ -230,19 +230,6 @@ func (state *TransactionMessagePlugin) Receive(ctx *network.PluginContext) error
 				return errors.New(failedVerificationMsg)
 			}
 		}
-		redeem := Redeem.String()
-		if strings.EqualFold(tx.Type, redeem) {
-			if !accSrv.VerifyRedeemAmount() {
-				failedVerificationMsg := "Redeem amount greater than account locked amount"
-				if err := ctx.Reply(network.WithSignMessage(context.Background(), true), &protoplugin.TxResponse{
-					TxId: "", Status: "failed", Queued: 0, Pending: 0,
-					Message: failedVerificationMsg,
-				}); err != nil {
-					return fmt.Errorf(fmt.Sprintf("Failed to reply to client :%v", err))
-				}
-				return errors.New(failedVerificationMsg)
-			}
-		}
 
 		// Check if asset has enough balance
 		// account.Balance > Tx.Value


### PR DESCRIPTION
## Problem
When redeem **HBTC** transaction is sent, blockchain implementation checks whether the account has BTC that is locked and fund to be redeemed is less than or equal to locked amount. However, this check fails when HBTC is transferred off chain or not in herdius chain. We need to support the redeem functionality even if HBTC transfer takes place outside of herdius chain or eco system.

Asana Link: 

## Solution
Removed the redeem balance verification call.
## Testing Done and Results
All test cases are passed.
Tested locally.
## Follow-up Work Needed
