### PR TITLE
Balance check fix

### DIFF
--- a/supervisor/service/service.go
+++ b/supervisor/service/service.go
@@ -892,7 +892,7 @@ func (s *Supervisor) updateStateForTxs(txs *txbyte.Txs, stateTrie statedb.Trie) 
 				log.Printf("Sender has no assets for the given symbol: %v", symbol)
 				continue
 			}
-			if balance.Balance <= tx.Asset.Value {
+			if balance.Balance < tx.Asset.Value {
 				plog.Error().Msgf("Sender does not have enough assets in account (%d) to send transaction amount (%d)", balance.Balance, tx.Asset.Value)
 				log.Printf("Sender does not have enough assets in account (%d) to send transaction amount (%d)", balance.Balance, tx.Asset.Value)
 				continue


### PR DESCRIPTION
## Problem
While performing external transactions, balance check was handled incorrectly where in even if the account had balance, transaction was failing due to low balance.
Asana Link: 

## Solution

## Testing Done and Results
All test cases passed.
Locally performed end to end testing.
## Follow-up Work Needed
