### PR TITLE
syncer: fix wrong config read in

### DIFF
--- a/cmd/herserver/main.go
+++ b/cmd/herserver/main.go
@@ -209,7 +209,7 @@ func main() {
 
 	lastBlock := blockchainSvc.GetLastBlock()
 
-	go syncer.SyncAllAccounts(accountStorage)
+	go syncer.SyncAllAccounts(accountStorage, env)
 
 	var lbh cmn.HexBytes
 	lastBlockHash := lastBlock.GetHeader().GetBlock_ID().GetBlockHash()

--- a/syncer/account.go
+++ b/syncer/account.go
@@ -24,20 +24,21 @@ type apiEndponts struct {
 }
 
 // SyncAllAccounts syncs all assets of available accounts.
-func SyncAllAccounts(exBal external.BalanceStorage) {
+func SyncAllAccounts(exBal external.BalanceStorage, env string) {
 	var rpc apiEndponts
 	viper.SetConfigName("config")   // Config file name without extension
 	viper.AddConfigPath("./config") // Path to config file
 	err := viper.ReadInConfig()
 	if err != nil {
 		log.Error().Err(err).Msg("failed to read config file")
-	} else {
-		rpc.ethRPC = viper.GetString("dev.ethrpc")
-		rpc.herTokenAddress = viper.GetString("dev.hercontractaddress")
-		rpc.btcRPC = viper.GetString("dev.blockchaininforpc")
-		rpc.hbtcRPC = viper.GetString("dev.hbtcrpc")
-		rpc.tezosRPC = viper.GetString("dev.tezosrpc")
+		return
 	}
+
+	rpc.ethRPC = viper.GetString(env + ".ethrpc")
+	rpc.herTokenAddress = viper.GetString(env + ".hercontractaddress")
+	rpc.btcRPC = viper.GetString(env + ".blockchaininforpc")
+	rpc.hbtcRPC = viper.GetString(env + ".hbtcrpc")
+	rpc.tezosRPC = viper.GetString(env + ".tezosrpc")
 
 	if strings.Index(rpc.ethRPC, ".infura.io") > -1 {
 		rpc.ethRPC += os.Getenv("INFURAID")

--- a/syncer/hbtc.go
+++ b/syncer/hbtc.go
@@ -33,27 +33,32 @@ func (hs *HBTCSyncer) GetExtBalance() error {
 	// If ETH account exists
 	ethAccount, ok := hs.syncer.Account.EBalances[hs.ethSymbol]
 	if !ok {
+		log.Warn().Msg("HBTC depends on ETH, but no ETH account available")
 		return errors.New("ETH account does not exists")
 	}
 
 	hbtcAccount, ok := ethAccount[hs.syncer.Account.FirstExternalAddress[hs.ethSymbol]]
 	if !ok {
+		log.Warn().Msg("HBTC does not exist")
 		return errors.New("HBTC account does not exists")
 	}
 
 	resp, err := http.Get(fmt.Sprintf("%s/%s", hs.RPC, hbtcAccount.Address))
 	if err != nil {
+		log.Error().Err(err).Msg("failed to get hbtc balance")
 		return err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
+		log.Error().Err(err).Msg("failed to read response body")
 		return err
 	}
 
 	balance, err := strconv.ParseInt(strings.TrimSuffix(string(body), "\n"), 10, 64)
 	if err != nil {
+		log.Error().Err(err).Msg("failed to parse response body")
 		return err
 	}
 


### PR DESCRIPTION
Currently, SyncAllAccounts always uses dev config. Passing env param to
SyncAllAccounts, so it can use different config for each env.

## Problem

Notion Link: https://www.notion.so/herdius/b081bd4254c14b1eb2ada917ce4ef406?v=7fec7434ea0849afa3c4db6676e9eb76&p=84146c5ca1e54759aeabecbf416331ad

## Solution

## Testing Done and Results

Passed.

## Follow-up Work Needed
