### PR TITLE
overflow issue

### DIFF
--- a/syncer/btctestnet.go
+++ b/syncer/btctestnet.go
@@ -119,19 +119,19 @@ func (btc *BTCTestNetSyncer) Update() {
 					log.Debug().Msg("lastExtBalance.Cmp(btc.ExtBalance) ============")
 
 					herEthBalance.Sub(lastExtBalance, btc.ExtBalance[btcAccount.Address])
+					if btcAccount.Balance >= herEthBalance.Uint64() {
+						btcAccount.Balance -= herEthBalance.Uint64()
+						btcAccount.LastBlockHeight = btc.BlockHeight[btcAccount.Address].Uint64()
+						btcAccount.Nonce = btc.Nonce[btcAccount.Address]
+						btc.Account.EBalances[assetSymbol][btcAccount.Address] = btcAccount
 
-					btcAccount.Balance -= herEthBalance.Uint64()
-					btcAccount.LastBlockHeight = btc.BlockHeight[btcAccount.Address].Uint64()
-					btcAccount.Nonce = btc.Nonce[btcAccount.Address]
-					btc.Account.EBalances[assetSymbol][btcAccount.Address] = btcAccount
-
-					last = last.UpdateLastExtBalanceByKey(storageKey, btc.ExtBalance[btcAccount.Address])
-					last = last.UpdateCurrentExtBalanceByKey(storageKey, btc.ExtBalance[btcAccount.Address])
-					last = last.UpdateIsFirstEntryByKey(storageKey, false)
-					last = last.UpdateIsNewAmountUpdateByKey(storageKey, true)
-					last = last.UpdateAccount(btc.Account)
-					btc.Storage.Set(btc.Account.Address, last)
-
+						last = last.UpdateLastExtBalanceByKey(storageKey, btc.ExtBalance[btcAccount.Address])
+						last = last.UpdateCurrentExtBalanceByKey(storageKey, btc.ExtBalance[btcAccount.Address])
+						last = last.UpdateIsFirstEntryByKey(storageKey, false)
+						last = last.UpdateIsNewAmountUpdateByKey(storageKey, true)
+						last = last.UpdateAccount(btc.Account)
+						btc.Storage.Set(btc.Account.Address, last)
+					}
 					log.Debug().Msgf("New account balance after external balance debit: %v\n", last)
 				}
 				continue
@@ -146,7 +146,7 @@ func (btc *BTCTestNetSyncer) Update() {
 			}
 			last = last.UpdateLastExtBalanceByKey(storageKey, btc.ExtBalance[btcAccount.Address])
 			last = last.UpdateCurrentExtBalanceByKey(storageKey, btc.ExtBalance[btcAccount.Address])
-			last = last.UpdateIsFirstEntryByKey(storageKey, true)
+			//	last = last.UpdateIsFirstEntryByKey(storageKey, true)
 			last = last.UpdateIsNewAmountUpdateByKey(storageKey, false)
 			btcAccount.UpdateBalance(btc.ExtBalance[btcAccount.Address].Uint64())
 			btcAccount.UpdateBlockHeight(btc.BlockHeight[btcAccount.Address].Uint64())

--- a/syncer/external.go
+++ b/syncer/external.go
@@ -78,22 +78,22 @@ func (es *ExternalSyncer) update(address string) {
 			// Balance of ETH in H1 	= Balance of ETH in H - ( last_External_Bal_In_Cache - Current_External_Bal )
 			if lastExtBalance.Cmp(es.ExtBalance[assetAccount.Address]) > 0 {
 				log.Debug().Msg("lastExtBalance.Cmp(es.ExtBalance) ============")
-
 				herEthBalance.Sub(lastExtBalance, es.ExtBalance[assetAccount.Address])
+				if assetAccount.Balance >= herEthBalance.Uint64() {
+					assetAccount.Balance -= herEthBalance.Uint64()
+					if es.BlockHeight[assetAccount.Address] != nil {
+						assetAccount.LastBlockHeight = es.BlockHeight[assetAccount.Address].Uint64()
+					}
+					assetAccount.Nonce = es.Nonce[assetAccount.Address]
+					es.Account.EBalances[assetSymbol][assetAccount.Address] = assetAccount
 
-				assetAccount.Balance -= herEthBalance.Uint64()
-				if es.BlockHeight[assetAccount.Address] != nil {
-					assetAccount.LastBlockHeight = es.BlockHeight[assetAccount.Address].Uint64()
+					last = last.UpdateLastExtBalanceByKey(storageKey, es.ExtBalance[assetAccount.Address])
+					last = last.UpdateCurrentExtBalanceByKey(storageKey, es.ExtBalance[assetAccount.Address])
+					last = last.UpdateIsFirstEntryByKey(storageKey, false)
+					last = last.UpdateIsNewAmountUpdateByKey(storageKey, true)
+					last = last.UpdateAccount(es.Account)
+					es.Storage.Set(es.Account.Address, last)
 				}
-				assetAccount.Nonce = es.Nonce[assetAccount.Address]
-				es.Account.EBalances[assetSymbol][assetAccount.Address] = assetAccount
-
-				last = last.UpdateLastExtBalanceByKey(storageKey, es.ExtBalance[assetAccount.Address])
-				last = last.UpdateCurrentExtBalanceByKey(storageKey, es.ExtBalance[assetAccount.Address])
-				last = last.UpdateIsFirstEntryByKey(storageKey, false)
-				last = last.UpdateIsNewAmountUpdateByKey(storageKey, true)
-				last = last.UpdateAccount(es.Account)
-				es.Storage.Set(es.Account.Address, last)
 				log.Debug().Msgf("New account balance after external balance debit: %v\n", last)
 			}
 			return


### PR DESCRIPTION
## Problem
Due to datatype overflow when converting bigint uint64, balances are getting updated incorrectly through syncer.
Notion Link: 
https://www.notion.so/herdius/Balance-overflow-c2f653dda77a4a438d762ba832f18c98
## Solution

## Testing Done and Results
Test cases are passed.
## Follow-up Work Needed
