### PR TITLE
syncer: fix btctestnet not update

### DIFF
--- a/syncer/btctestnet.go
+++ b/syncer/btctestnet.go
@@ -146,7 +146,7 @@ func (btc *BTCTestNetSyncer) Update() {
 			}
 			last = last.UpdateLastExtBalanceByKey(storageKey, btc.ExtBalance[btcAccount.Address])
 			last = last.UpdateCurrentExtBalanceByKey(storageKey, btc.ExtBalance[btcAccount.Address])
-			//	last = last.UpdateIsFirstEntryByKey(storageKey, true)
+			last = last.UpdateIsFirstEntryByKey(storageKey, true)
 			last = last.UpdateIsNewAmountUpdateByKey(storageKey, false)
 			btcAccount.UpdateBalance(btc.ExtBalance[btcAccount.Address].Uint64())
 			btcAccount.UpdateBlockHeight(btc.BlockHeight[btcAccount.Address].Uint64())


### PR DESCRIPTION
first entry in external storage is not updated, causing btctestnet stop
sync external balance.

## Problem

Asana Link: 

## Solution

## Testing Done and Results

## Follow-up Work Needed
