### PR TITLE
Balance verification bug during redeem

### DIFF
--- a/accounts/account/service.go
+++ b/accounts/account/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	txValue         uint64
 	txLockedAmount  uint64
 	txRedeemAmount  uint64
+	txType          string
 }
 
 // Account returns state db account
@@ -123,6 +124,16 @@ func (s *Service) TxRedeemAmount() uint64 {
 // SetTxRedeemAmount sets transaction transfer redeem amount
 func (s *Service) SetTxRedeemAmount(txRedeemAmount uint64) {
 	s.txRedeemAmount = txRedeemAmount
+}
+
+// TxType returns service tx type
+func (s *Service) TxType() string {
+	return s.txType
+}
+
+// SetTxType sets Service tx type
+func (s *Service) SetTxType(txType string) {
+	s.txType = txType
 }
 
 var (
@@ -248,9 +259,15 @@ func (s *Service) VerifyAccountNonce(a *protobuf.Account, txNonce uint64) bool {
 
 // AccountExternalAddressExist reports whether an external address existed in EBalances
 func (s *Service) AccountExternalAddressExist() bool {
-	if s.account != nil && s.account.EBalances != nil && s.account.EBalances[s.assetSymbol] != nil {
-		if asset := s.account.EBalances[s.assetSymbol].Asset; asset != nil {
-			_, ok := asset[s.extAddress]
+	assetSymbol := s.assetSymbol
+	extAddress := s.extAddress
+	if strings.EqualFold(s.txType, "Redeem") &&
+		(strings.EqualFold(assetSymbol, "HBTC") || strings.EqualFold(assetSymbol, "HTZX")) {
+		extAddress = s.account.FirstExternalAddress["ETH"]
+	}
+	if s.account != nil && s.account.EBalances != nil && s.account.EBalances[assetSymbol] != nil {
+		if asset := s.account.EBalances[assetSymbol].Asset; asset != nil {
+			_, ok := asset[extAddress]
 			return ok
 		}
 	}

--- a/accounts/account/service_test.go
+++ b/accounts/account/service_test.go
@@ -231,3 +231,49 @@ func TestVerifyBTCRedeemAmount(t *testing.T) {
 	accService.SetTxRedeemAmount(2)
 	assert.False(t, accService.VerifyRedeemAmount())
 }
+
+func TestAccountExternalAddressExistForRedeemTrue(t *testing.T) {
+	accService := NewAccountService()
+	eBalance := &protobuf.EBalance{
+		Address: "0xD8f647855876549d2623f52126CE40D053a2ef6A",
+		Balance: 1,
+	}
+	eBalances := make(map[string]*protobuf.EBalanceAsset)
+	eBalances["ETH"] = &protobuf.EBalanceAsset{}
+	eBalances["HBTC"] = &protobuf.EBalanceAsset{}
+	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
+	eBalances["HBTC"].Asset = make(map[string]*protobuf.EBalance)
+	eBalances["ETH"].Asset[eBalance.Address] = eBalance
+	eBalances["HBTC"].Asset[eBalance.Address] = eBalance
+	firstExternalAddress := make(map[string]string)
+	firstExternalAddress["ETH"] = "0xD8f647855876549d2623f52126CE40D053a2ef6A"
+	account := &protobuf.Account{Balance: 1, EBalances: eBalances, FirstExternalAddress: firstExternalAddress}
+	accService.SetAccount(account)
+	accService.SetAssetSymbol("HBTC")
+	accService.SetTxType("Redeem")
+	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A")
+	assert.True(t, accService.AccountExternalAddressExist())
+}
+
+func TestAccountExternalAddressExistForRedeemFalse(t *testing.T) {
+	accService := NewAccountService()
+	eBalance := &protobuf.EBalance{
+		Address: "0xD8f647855876549d2623f52126CE40D053a2ef6A",
+		Balance: 1,
+	}
+	eBalances := make(map[string]*protobuf.EBalanceAsset)
+	eBalances["ETH"] = &protobuf.EBalanceAsset{}
+	eBalances["HBTC"] = &protobuf.EBalanceAsset{}
+	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
+	eBalances["HBTC"].Asset = make(map[string]*protobuf.EBalance)
+	eBalances["ETH"].Asset[eBalance.Address] = eBalance
+	eBalances["HBTC"].Asset[eBalance.Address] = eBalance
+	firstExternalAddress := make(map[string]string)
+	firstExternalAddress["ETH"] = "0xD8f647855876549d2623f52126CE40D053a2ef6A-Another-Address"
+	account := &protobuf.Account{Balance: 1, EBalances: eBalances, FirstExternalAddress: firstExternalAddress}
+	accService.SetAccount(account)
+	accService.SetAssetSymbol("HBTC")
+	accService.SetTxType("Redeem")
+	accService.SetExtAddress("n2WH6nSNx7ZEwpR5rfCuvbEXX43am3TcNY")
+	assert.False(t, accService.AccountExternalAddressExist())
+}

--- a/hbi/message/plugin.go
+++ b/hbi/message/plugin.go
@@ -135,6 +135,7 @@ func (state *TransactionMessagePlugin) Receive(ctx *network.PluginContext) error
 		accSrv.SetTxValue(tx.Asset.Value)
 		accSrv.SetTxLockedAmount(tx.Asset.LockedAmount)
 		accSrv.SetTxRedeemAmount(tx.Asset.RedeemedAmount)
+		accSrv.SetTxType(tx.Type)
 		acc, err := accSrv.GetAccountByAddress(msg.Tx.GetSenderAddress())
 		if err != nil {
 			if err := ctx.Reply(network.WithSignMessage(context.Background(), true), &protoplugin.TxResponse{


### PR DESCRIPTION
## Problem
While redeem transaction is sent, then balance should be verified in HBTC or HTZX address instead it is verifying the BTC or TZX address.
Notion Link: 

## Solution
Added to verify the tx type based on which balances will be verified.
## Testing Done and Results
Locally it is tested and working fine.
Test cases are also passed.
## Follow-up Work Needed
