### PR TITLE
Feature/refactoring symbol

### DIFF
--- a/accounts/account/service.go
+++ b/accounts/account/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/herdius/herdius-core/crypto/secp256k1"
 	cmn "github.com/herdius/herdius-core/libs/common"
 	"github.com/herdius/herdius-core/storage/state/statedb"
+	aSymbol "github.com/herdius/herdius-core/symbol"
 	amino "github.com/tendermint/go-amino"
 )
 
@@ -226,7 +227,7 @@ func (s *Service) GetAccountByAddress(address string) (*protobuf.Account, error)
 func (s *Service) VerifyAccountBalance() bool {
 	symbol := strings.ToUpper(s.assetSymbol)
 	// Get the balance of required asset
-	if strings.EqualFold(symbol, "HER") {
+	if strings.EqualFold(symbol, aSymbol.HER) {
 		if s.account.Balance >= s.txValue {
 			return true
 		}
@@ -262,8 +263,8 @@ func (s *Service) AccountExternalAddressExist() bool {
 	assetSymbol := s.assetSymbol
 	extAddress := s.extAddress
 	if strings.EqualFold(s.txType, "Redeem") &&
-		(strings.EqualFold(assetSymbol, "HBTC") || strings.EqualFold(assetSymbol, "HTZX")) {
-		extAddress = s.account.FirstExternalAddress["ETH"]
+		(strings.EqualFold(assetSymbol, aSymbol.HBTC) || strings.EqualFold(assetSymbol, aSymbol.HTZX)) {
+		extAddress = s.account.FirstExternalAddress[aSymbol.ETH]
 	}
 	if s.account != nil && s.account.EBalances != nil && s.account.EBalances[assetSymbol] != nil {
 		if asset := s.account.EBalances[assetSymbol].Asset; asset != nil {
@@ -301,9 +302,9 @@ func (s *Service) VerifyLockedAmount() bool {
 // VerifyRedeemAmount checks account have proper locked amount for redeeming
 func (s *Service) VerifyRedeemAmount() bool {
 	log.Printf("Account before Redeem: %+v", s.account)
-	if strings.EqualFold(s.assetSymbol, "HBTC") {
-		if s.account != nil && s.account.LockBalances != nil && s.account.LockBalances["BTC"] != nil {
-			if asset := s.account.LockBalances["BTC"].Asset; asset != nil {
+	if strings.EqualFold(s.assetSymbol, aSymbol.HBTC) {
+		if s.account != nil && s.account.LockBalances != nil && s.account.LockBalances[aSymbol.BTC] != nil {
+			if asset := s.account.LockBalances[aSymbol.BTC].Asset; asset != nil {
 				return s.txRedeemAmount <= asset[s.extAddress]
 			}
 		}

--- a/accounts/account/service_test.go
+++ b/accounts/account/service_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/herdius/herdius-core/accounts/protobuf"
 	"github.com/herdius/herdius-core/crypto/secp256k1"
+	aSymbol "github.com/herdius/herdius-core/symbol"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,7 +16,7 @@ func TestVerifyAccountBalanceTrue(t *testing.T) {
 	account := &protobuf.Account{Balance: 10}
 	accService.SetAccount(account)
 	accService.SetTxValue(5)
-	accService.SetAssetSymbol("HER")
+	accService.SetAssetSymbol(aSymbol.HER)
 	assert.True(t, accService.VerifyAccountBalance())
 }
 
@@ -24,7 +25,7 @@ func TestVerifyAccountBalanceFalse(t *testing.T) {
 	accService := NewAccountService()
 	accService.SetAccount(account)
 	accService.SetTxValue(5)
-	accService.SetAssetSymbol("HER")
+	accService.SetAssetSymbol(aSymbol.HER)
 	assert.False(t, accService.VerifyAccountBalance())
 }
 
@@ -34,15 +35,15 @@ func TestVerifyExternalAssetBalanceTrue(t *testing.T) {
 		Balance: 10,
 	}
 	eBalances := make(map[string]*protobuf.EBalanceAsset)
-	eBalances["ETH"] = &protobuf.EBalanceAsset{}
-	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
-	eBalances["ETH"].Asset[eBalance.Address] = eBalance
+	eBalances[aSymbol.ETH] = &protobuf.EBalanceAsset{}
+	eBalances[aSymbol.ETH].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[aSymbol.ETH].Asset[eBalance.Address] = eBalance
 	account := &protobuf.Account{Balance: 10, EBalances: eBalances}
 	accService := NewAccountService()
 	accService.SetAccount(account)
 	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A")
 	accService.SetTxValue(1)
-	accService.SetAssetSymbol("ETH")
+	accService.SetAssetSymbol(aSymbol.ETH)
 	assert.True(t, accService.VerifyAccountBalance())
 }
 
@@ -52,15 +53,15 @@ func TestVerifyExternalAssetBalanceFalse(t *testing.T) {
 		Balance: 1,
 	}
 	eBalances := make(map[string]*protobuf.EBalanceAsset)
-	eBalances["ETH"] = &protobuf.EBalanceAsset{}
-	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
-	eBalances["ETH"].Asset[eBalance.Address] = eBalance
+	eBalances[aSymbol.ETH] = &protobuf.EBalanceAsset{}
+	eBalances[aSymbol.ETH].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[aSymbol.ETH].Asset[eBalance.Address] = eBalance
 	account := &protobuf.Account{Balance: 1, EBalances: eBalances}
 	accService := NewAccountService()
 	accService.SetAccount(account)
 	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A")
 	accService.SetTxValue(2)
-	accService.SetAssetSymbol("ETH")
+	accService.SetAssetSymbol(aSymbol.ETH)
 	assert.False(t, accService.VerifyAccountBalance())
 }
 
@@ -120,9 +121,9 @@ func TestAccountExternalAddressExistFalse(t *testing.T) {
 		Balance: 1,
 	}
 	eBalances := make(map[string]*protobuf.EBalanceAsset)
-	eBalances["ETH"] = &protobuf.EBalanceAsset{}
-	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
-	eBalances["ETH"].Asset[eBalance.Address] = eBalance
+	eBalances[aSymbol.ETH] = &protobuf.EBalanceAsset{}
+	eBalances[aSymbol.ETH].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[aSymbol.ETH].Asset[eBalance.Address] = eBalance
 	account := &protobuf.Account{Balance: 1, EBalances: eBalances}
 	accService.SetAccount(account)
 	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A-WrongOne")
@@ -135,9 +136,9 @@ func TestAccountExternalAddressExistTrue(t *testing.T) {
 		Balance: 1,
 	}
 	eBalances := make(map[string]*protobuf.EBalanceAsset)
-	eBalances["ETH"] = &protobuf.EBalanceAsset{}
-	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
-	eBalances["ETH"].Asset[eBalance.Address] = eBalance
+	eBalances[aSymbol.ETH] = &protobuf.EBalanceAsset{}
+	eBalances[aSymbol.ETH].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[aSymbol.ETH].Asset[eBalance.Address] = eBalance
 	account := &protobuf.Account{Balance: 1, EBalances: eBalances}
 	accService.SetAccount(account)
 	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A")
@@ -146,24 +147,24 @@ func TestAccountExternalAddressExistTrue(t *testing.T) {
 
 func TestVerifyAccountEBalancesLimit(t *testing.T) {
 	eBalances := make(map[string]*protobuf.EBalanceAsset)
-	eBalances["ETH"] = &protobuf.EBalanceAsset{}
-	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[aSymbol.ETH] = &protobuf.EBalanceAsset{}
+	eBalances[aSymbol.ETH].Asset = make(map[string]*protobuf.EBalance)
 	for i := 0; i < 1023; i++ {
 		address := fmt.Sprintf("%d", i)
-		eBalances["ETH"].Asset[address] = &protobuf.EBalance{Address: address}
+		eBalances[aSymbol.ETH].Asset[address] = &protobuf.EBalance{Address: address}
 	}
 	account := &protobuf.Account{Balance: 1, EBalances: eBalances}
 	accService := NewAccountService()
 	accService.SetAccount(account)
-	accService.SetAssetSymbol("ETH")
+	accService.SetAssetSymbol(aSymbol.ETH)
 	assert.False(t, accService.AccountEBalancePerAssetReachLimit())
-	eBalances["ETH"].Asset["1024"] = nil
+	eBalances[aSymbol.ETH].Asset["1024"] = nil
 	assert.True(t, accService.AccountEBalancePerAssetReachLimit())
 }
 
 func TestVerifyLockedAmount(t *testing.T) {
 	accService := NewAccountService()
-	symbol := "ETH"
+	symbol := aSymbol.ETH
 	extAddr := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	eBalance := &protobuf.EBalance{
 		Address: extAddr,
@@ -185,7 +186,7 @@ func TestVerifyLockedAmount(t *testing.T) {
 
 func TestVerifyAccountBalanceWithLockAmount(t *testing.T) {
 	accService := NewAccountService()
-	symbol := "ETH"
+	symbol := aSymbol.ETH
 	extAddr := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	eBalance := &protobuf.EBalance{
 		Address: extAddr,
@@ -215,7 +216,7 @@ func TestVerifyAccountBalanceWithLockAmount(t *testing.T) {
 
 func TestVerifyBTCRedeemAmount(t *testing.T) {
 	accService := NewAccountService()
-	symbol := "BTC"
+	symbol := aSymbol.BTC
 	extAddr := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	lockBalances := make(map[string]*protobuf.LockBalanceAsset)
 	lockBalances[symbol] = &protobuf.LockBalanceAsset{}
@@ -224,7 +225,7 @@ func TestVerifyBTCRedeemAmount(t *testing.T) {
 
 	account := &protobuf.Account{Balance: 1, LockBalances: lockBalances}
 	accService.SetAccount(account)
-	accService.SetAssetSymbol("HBTC")
+	accService.SetAssetSymbol(aSymbol.HBTC)
 	accService.SetTxRedeemAmount(1)
 	accService.SetExtAddress(extAddr)
 	assert.True(t, accService.VerifyRedeemAmount())
@@ -239,17 +240,17 @@ func TestAccountExternalAddressExistForRedeemTrue(t *testing.T) {
 		Balance: 1,
 	}
 	eBalances := make(map[string]*protobuf.EBalanceAsset)
-	eBalances["ETH"] = &protobuf.EBalanceAsset{}
-	eBalances["HBTC"] = &protobuf.EBalanceAsset{}
-	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
-	eBalances["HBTC"].Asset = make(map[string]*protobuf.EBalance)
-	eBalances["ETH"].Asset[eBalance.Address] = eBalance
-	eBalances["HBTC"].Asset[eBalance.Address] = eBalance
+	eBalances[aSymbol.ETH] = &protobuf.EBalanceAsset{}
+	eBalances[aSymbol.HBTC] = &protobuf.EBalanceAsset{}
+	eBalances[aSymbol.ETH].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[aSymbol.HBTC].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[aSymbol.ETH].Asset[eBalance.Address] = eBalance
+	eBalances[aSymbol.HBTC].Asset[eBalance.Address] = eBalance
 	firstExternalAddress := make(map[string]string)
-	firstExternalAddress["ETH"] = "0xD8f647855876549d2623f52126CE40D053a2ef6A"
+	firstExternalAddress[aSymbol.ETH] = "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	account := &protobuf.Account{Balance: 1, EBalances: eBalances, FirstExternalAddress: firstExternalAddress}
 	accService.SetAccount(account)
-	accService.SetAssetSymbol("HBTC")
+	accService.SetAssetSymbol(aSymbol.HBTC)
 	accService.SetTxType("Redeem")
 	accService.SetExtAddress("0xD8f647855876549d2623f52126CE40D053a2ef6A")
 	assert.True(t, accService.AccountExternalAddressExist())
@@ -262,17 +263,17 @@ func TestAccountExternalAddressExistForRedeemFalse(t *testing.T) {
 		Balance: 1,
 	}
 	eBalances := make(map[string]*protobuf.EBalanceAsset)
-	eBalances["ETH"] = &protobuf.EBalanceAsset{}
-	eBalances["HBTC"] = &protobuf.EBalanceAsset{}
-	eBalances["ETH"].Asset = make(map[string]*protobuf.EBalance)
-	eBalances["HBTC"].Asset = make(map[string]*protobuf.EBalance)
-	eBalances["ETH"].Asset[eBalance.Address] = eBalance
-	eBalances["HBTC"].Asset[eBalance.Address] = eBalance
+	eBalances[aSymbol.ETH] = &protobuf.EBalanceAsset{}
+	eBalances[aSymbol.HBTC] = &protobuf.EBalanceAsset{}
+	eBalances[aSymbol.ETH].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[aSymbol.HBTC].Asset = make(map[string]*protobuf.EBalance)
+	eBalances[aSymbol.ETH].Asset[eBalance.Address] = eBalance
+	eBalances[aSymbol.HBTC].Asset[eBalance.Address] = eBalance
 	firstExternalAddress := make(map[string]string)
-	firstExternalAddress["ETH"] = "0xD8f647855876549d2623f52126CE40D053a2ef6A-Another-Address"
+	firstExternalAddress[aSymbol.ETH] = "0xD8f647855876549d2623f52126CE40D053a2ef6A-Another-Address"
 	account := &protobuf.Account{Balance: 1, EBalances: eBalances, FirstExternalAddress: firstExternalAddress}
 	accService.SetAccount(account)
-	accService.SetAssetSymbol("HBTC")
+	accService.SetAssetSymbol(aSymbol.HBTC)
 	accService.SetTxType("Redeem")
 	accService.SetExtAddress("n2WH6nSNx7ZEwpR5rfCuvbEXX43am3TcNY")
 	assert.False(t, accService.AccountExternalAddressExist())

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	gomock "github.com/golang/mock/gomock"
-		"github.com/stretchr/testify/assert"
-			"github.com/herdius/herdius-core/aws/aws_mocks"
+	"github.com/herdius/herdius-core/aws/aws_mocks"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTryBackupBaseBlock(t *testing.T) {

--- a/blockchain/protobuf/stream.pb.go
+++ b/blockchain/protobuf/stream.pb.go
@@ -5,9 +5,10 @@ package protobuf
 
 import (
 	fmt "fmt"
+	math "math"
+
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/golang/protobuf/proto"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/blockchain/service_test.go
+++ b/blockchain/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/herdius/herdius-core/crypto/secp256k1"
 	pluginproto "github.com/herdius/herdius-core/hbi/protobuf"
 	"github.com/herdius/herdius-core/storage/db"
+	"github.com/herdius/herdius-core/symbol"
 
 	"github.com/herdius/herdius-core/crypto/herhash"
 	txbyte "github.com/herdius/herdius-core/tx"
@@ -48,12 +49,12 @@ func TestGetTxsByAddressAndAsset(t *testing.T) {
 	privKey := secp256k1.GenPrivKey()
 	addBlocks(privKey, t)
 	txSrv := TxService{}
-	txs, err := txSrv.GetTxsByAssetAndAddress("HER", privKey.PubKey().GetAddress())
+	txs, err := txSrv.GetTxsByAssetAndAddress(symbol.HER, privKey.PubKey().GetAddress())
 	require.Nil(t, err)
 
 	assert.Equal(t, 1, len(txs.GetTxs()), "Total HER transactions should be 1")
 
-	btcTxs, err := txSrv.GetTxsByAssetAndAddress("BTC", privKey.PubKey().GetAddress())
+	btcTxs, err := txSrv.GetTxsByAssetAndAddress(symbol.BTC, privKey.PubKey().GetAddress())
 	require.Nil(t, err)
 
 	assert.Equal(t, 0, len(btcTxs.GetTxs()), "Total BTC transactions should be 0")
@@ -141,7 +142,7 @@ func getTx(nonce int, privKey secp256k1.PrivKeySecp256k1) pluginproto.Tx {
 	pubKey := privKey.PubKey()
 	sign, _ := privKey.Sign(msg)
 	asset := &pluginproto.Asset{
-		Symbol: "HER",
+		Symbol: symbol.HER,
 	}
 	tx := pluginproto.Tx{
 		SenderAddress: pubKey.GetAddress(),

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/herdius/herdius-core/config"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 // Checker checks availability of asset network
@@ -25,12 +26,12 @@ func New(env string) *Network {
 	c := config.GetConfiguration(env)
 	n := &Network{}
 	n.checker = make(map[string]Checker)
-	n.checker["BTC"] = &BTC{c.CheckerBtcURL}
-	n.checker["HER"] = &HER{}
-	n.checker["ETH"] = &ETH{c.EthRPCURL}
-	n.checker["HBTC"] = &ETH{c.EthRPCURL}
-	n.checker["HTZX"] = &ETH{c.EthRPCURL}
-	n.checker["HLTC"] = &ETH{c.EthRPCURL}
+	n.checker[symbol.BTC] = &BTC{c.CheckerBtcURL}
+	n.checker[symbol.HER] = &HER{}
+	n.checker[symbol.ETH] = &ETH{c.EthRPCURL}
+	n.checker[symbol.HBTC] = &ETH{c.EthRPCURL}
+	n.checker[symbol.HTZX] = &ETH{c.EthRPCURL}
+	n.checker[symbol.HLTC] = &ETH{c.EthRPCURL}
 	return n
 }
 

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/herdius/herdius-core/symbol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,9 +38,9 @@ func TestBTCChecker(t *testing.T) {
 
 func TestCheckerNetwork(t *testing.T) {
 	n := New("dev")
-	require.True(t, n.Check("HER"))
+	require.True(t, n.Check(symbol.HER))
 
-	if !n.Check("BTC") {
+	if !n.Check(symbol.BTC) {
 		t.Log("Bitcoin network is down")
 	}
 

--- a/cmd/testdata/gentx.go
+++ b/cmd/testdata/gentx.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/herdius/herdius-core/p2p/key"
 	"github.com/herdius/herdius-core/supervisor/transaction"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 func main() {
@@ -43,7 +44,7 @@ func createTxs() {
 				Senderpubkey:  pubKey.Bytes(),
 				Fee:           []byte("0"),
 				Assetcategory: "Crypto",
-				Assetname:     "BTC",
+				Assetname:     symbol.BTC,
 				Value:         []byte("10"),
 				Signature:     sign,
 				Message:       "Transfer 10 BTC",

--- a/storage/mempool/mempool_test.go
+++ b/storage/mempool/mempool_test.go
@@ -8,6 +8,7 @@ import (
 	acc "github.com/herdius/herdius-core/accounts/protobuf"
 	"github.com/herdius/herdius-core/hbi/protobuf"
 	"github.com/herdius/herdius-core/libs/common"
+	"github.com/herdius/herdius-core/symbol"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -70,7 +71,7 @@ func TestProcessQueueGap(t *testing.T) {
 func NewTx(i uint64, address string) (protobuf.Tx, string) {
 	asset := &protobuf.Asset{
 		Category: "crypto",
-		Symbol:   "HER",
+		Symbol:   symbol.HER,
 		Network:  "Herdius",
 		Value:    100,
 		Fee:      1,

--- a/supervisor/service/service_test.go
+++ b/supervisor/service/service_test.go
@@ -8,25 +8,23 @@ import (
 	"os"
 	"testing"
 
-	"github.com/herdius/herdius-core/blockchain/protobuf"
-	"github.com/herdius/herdius-core/storage/db"
-	"github.com/herdius/herdius-core/storage/state/statedb"
-
-	ed25519 "github.com/herdius/herdius-core/crypto/ed"
-	pluginproto "github.com/herdius/herdius-core/hbi/protobuf"
-
-	"github.com/herdius/herdius-core/crypto/secp256k1"
-	"github.com/herdius/herdius-core/supervisor/transaction"
-
-	external "github.com/herdius/herdius-core/storage/exbalance"
-
-	txbyte "github.com/herdius/herdius-core/tx"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/herdius/herdius-core/blockchain/protobuf"
+	ed25519 "github.com/herdius/herdius-core/crypto/ed"
+	"github.com/herdius/herdius-core/crypto/secp256k1"
+	pluginproto "github.com/herdius/herdius-core/hbi/protobuf"
+	"github.com/herdius/herdius-core/storage/db"
+	external "github.com/herdius/herdius-core/storage/exbalance"
+	"github.com/herdius/herdius-core/storage/state/statedb"
+	"github.com/herdius/herdius-core/supervisor/transaction"
+	aSymbol "github.com/herdius/herdius-core/symbol"
+	txbyte "github.com/herdius/herdius-core/tx"
 )
 
 func TestRegisterNewHERAddress(t *testing.T) {
 	asset := &pluginproto.Asset{
-		Symbol: "HER",
+		Symbol: aSymbol.HER,
 	}
 	tx := &pluginproto.Tx{
 		SenderAddress: "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
@@ -40,7 +38,7 @@ func TestRegisterNewHERAddress(t *testing.T) {
 
 func TestUpdateHERAccountBalance(t *testing.T) {
 	asset := &pluginproto.Asset{
-		Symbol: "HER",
+		Symbol: aSymbol.HER,
 	}
 	tx := &pluginproto.Tx{
 		SenderAddress: "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
@@ -54,7 +52,7 @@ func TestUpdateHERAccountBalance(t *testing.T) {
 
 	// Update 10 HER tokens to existing HER Account
 	asset = &pluginproto.Asset{
-		Symbol: "HER",
+		Symbol: aSymbol.HER,
 		Value:  10,
 		Nonce:  2,
 	}
@@ -70,7 +68,7 @@ func TestUpdateHERAccountBalance(t *testing.T) {
 }
 
 func TestRegisterNewETHAddress(t *testing.T) {
-	symbol := "ETH"
+	symbol := aSymbol.ETH
 	extSenderAddress := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	asset := &pluginproto.Asset{
 		Symbol:                symbol,
@@ -94,7 +92,7 @@ func TestRegisterNewETHAddress(t *testing.T) {
 }
 
 func TestRegisterMultipleExternalAssets(t *testing.T) {
-	symbol := "ETH"
+	symbol := aSymbol.ETH
 	extSenderAddress := " 0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	// First add ETH
 	asset := &pluginproto.Asset{
@@ -118,7 +116,7 @@ func TestRegisterMultipleExternalAssets(t *testing.T) {
 	assert.Equal(t, tx.Asset.ExternalSenderAddress, account.EBalances[symbol][extSenderAddress].Address)
 	assert.Equal(t, extSenderAddress, account.FirstExternalAddress[symbol])
 
-	newSymbol := "BTC"
+	newSymbol := aSymbol.BTC
 	newExtSenderAddress := "Bitcoin-Address"
 	// Second add BTC
 	asset = &pluginproto.Asset{
@@ -140,7 +138,7 @@ func TestRegisterMultipleExternalAssets(t *testing.T) {
 	assert.Equal(t, newExtSenderAddress, account.FirstExternalAddress[newSymbol])
 
 	// Tezos support
-	newXTZSymbol := "XTZ"
+	newXTZSymbol := aSymbol.XTZ
 	newTezosExtSenderAddress := "Tezos-Address"
 	// Third add XTZ
 	asset = &pluginproto.Asset{
@@ -163,7 +161,7 @@ func TestRegisterMultipleExternalAssets(t *testing.T) {
 }
 
 func TestUpdateExternalAccountBalance(t *testing.T) {
-	symbol := "ETH"
+	symbol := aSymbol.ETH
 	extSenderAddress := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	asset := &pluginproto.Asset{
 		Symbol:                symbol,
@@ -211,13 +209,13 @@ func TestIsExternalAssetAddressExistTrue(t *testing.T) {
 	addr := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	eBal := statedb.EBalance{Address: addr}
 	eBals := make(map[string]map[string]statedb.EBalance)
-	eBals["ETH"] = make(map[string]statedb.EBalance)
-	eBals["ETH"][addr] = eBal
+	eBals[aSymbol.ETH] = make(map[string]statedb.EBalance)
+	eBals[aSymbol.ETH][addr] = eBal
 	account := &statedb.Account{
 		Address:   "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
 		EBalances: eBals,
 	}
-	assert.True(t, isExternalAssetAddressExist(account, "ETH", addr))
+	assert.True(t, isExternalAssetAddressExist(account, aSymbol.ETH, addr))
 }
 func TestIsExternalAssetAddressExistFalse(t *testing.T) {
 	addr := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
@@ -226,35 +224,35 @@ func TestIsExternalAssetAddressExistFalse(t *testing.T) {
 		Address:   "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
 		EBalances: eBals,
 	}
-	assert.False(t, isExternalAssetAddressExist(account, "ETH", addr))
+	assert.False(t, isExternalAssetAddressExist(account, aSymbol.ETH, addr))
 }
 
 func TestExternalAssetWithdrawFromAnAccount(t *testing.T) {
 	addr := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	eBal := statedb.EBalance{Balance: 10, Address: addr}
 	eBals := make(map[string]map[string]statedb.EBalance)
-	eBals["ETH"] = make(map[string]statedb.EBalance)
-	eBals["ETH"][addr] = eBal
+	eBals[aSymbol.ETH] = make(map[string]statedb.EBalance)
+	eBals[aSymbol.ETH][addr] = eBal
 	account := &statedb.Account{
 		Address:   "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
 		EBalances: eBals,
 	}
-	withdraw(account, "ETH", addr, 5)
-	assert.Equal(t, uint64(5), account.EBalances["ETH"][addr].Balance)
+	withdraw(account, aSymbol.ETH, addr, 5)
+	assert.Equal(t, uint64(5), account.EBalances[aSymbol.ETH][addr].Balance)
 }
 
 func TestExternalAssetDepositToAnAccount(t *testing.T) {
 	addr := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	eBal := statedb.EBalance{Balance: 10, Address: addr}
 	eBals := make(map[string]map[string]statedb.EBalance)
-	eBals["ETH"] = make(map[string]statedb.EBalance)
-	eBals["ETH"][addr] = eBal
+	eBals[aSymbol.ETH] = make(map[string]statedb.EBalance)
+	eBals[aSymbol.ETH][addr] = eBal
 	account := &statedb.Account{
 		Address:   "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
 		EBalances: eBals,
 	}
-	deposit(account, "ETH", addr, 5)
-	assert.Equal(t, uint64(15), account.EBalances["ETH"][addr].Balance)
+	deposit(account, aSymbol.ETH, addr, 5)
+	assert.Equal(t, uint64(15), account.EBalances[aSymbol.ETH][addr].Balance)
 }
 
 func TestRemoveValidator(t *testing.T) {
@@ -306,7 +304,7 @@ func getTx(nonce int) transaction.Tx {
 		Nonce:    string(nonce),
 		Fee:      "100",
 		Category: "Crypto",
-		Symbol:   "BTC",
+		Symbol:   aSymbol.BTC,
 		Value:    "10",
 		Network:  "Herdius",
 	}
@@ -347,7 +345,7 @@ func getTxSecp256k1Account(nonce int) transaction.Tx {
 		Nonce:    string(nonce),
 		Fee:      "100",
 		Category: "Crypto",
-		Symbol:   "BTC",
+		Symbol:   aSymbol.BTC,
 		Value:    "10",
 		Network:  "Herdius",
 	}
@@ -453,7 +451,7 @@ func TestUpdateStateWithNewExternalBalance(t *testing.T) {
 }
 
 func TestUpdateAccountLockedBalance(t *testing.T) {
-	symbol := "ETH"
+	symbol := aSymbol.ETH
 	lockedAmount := uint64(10)
 	extSenderAddress := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	asset := &pluginproto.Asset{
@@ -488,7 +486,7 @@ func TestUpdateAccountLockedBalance(t *testing.T) {
 	assert.Equal(t, lockedAmount, account.LockedBalance[symbol][extSenderAddress])
 }
 func TestUpdateAccountLockedBalanceMintHBTCFirst(t *testing.T) {
-	symbol := "BTC"
+	symbol := aSymbol.BTC
 	lockedAmount := uint64(10)
 	extSenderAddress := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	asset := &pluginproto.Asset{
@@ -520,15 +518,15 @@ func TestUpdateAccountLockedBalanceMintHBTCFirst(t *testing.T) {
 		FirstExternalAddress: make(map[string]string),
 		EBalances:            eBalances,
 	}
-	account.FirstExternalAddress["ETH"] = "0xD8f647855876549d2623f52126CE40D053a2ef6A"
+	account.FirstExternalAddress[aSymbol.ETH] = "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	account = updateAccountLockedBalance(account, tx)
 	assert.Equal(t, lockedAmount, account.LockedBalance[symbol][extSenderAddress])
-	assert.Equal(t, uint64(0), account.EBalances["HBTC"]["0xD8f647855876549d2623f52126CE40D053a2ef6A"].Balance)
+	assert.Equal(t, uint64(0), account.EBalances[aSymbol.HBTC]["0xD8f647855876549d2623f52126CE40D053a2ef6A"].Balance)
 
 }
 
 func TestUpdateRedeemAccountLockedBalance(t *testing.T) {
-	symbol := "BTC"
+	symbol := aSymbol.BTC
 	lockedAmount := uint64(10)
 	extSenderAddress := "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	asset := &pluginproto.Asset{
@@ -555,14 +553,14 @@ func TestUpdateRedeemAccountLockedBalance(t *testing.T) {
 	eBalances[symbol][extAddr] = eBalance
 	account := &statedb.Account{
 		Address:              "HHy1CuT3UxCGJ3BHydLEvR5ut6HRy2qUvm",
-		FirstExternalAddress: map[string]string{"ETH": extAddr},
+		FirstExternalAddress: map[string]string{aSymbol.ETH: extAddr},
 		EBalances:            eBalances,
 	}
 	account = updateAccountLockedBalance(account, tx)
 	assert.Equal(t, lockedAmount, account.LockedBalance[symbol][extSenderAddress])
 
 	// Redeem test
-	symbol = "HBTC"
+	symbol = aSymbol.HBTC
 	value := uint64(5)
 	extSenderAddress = "0xD8f647855876549d2623f52126CE40D053a2ef6A"
 	asset = &pluginproto.Asset{
@@ -579,8 +577,8 @@ func TestUpdateRedeemAccountLockedBalance(t *testing.T) {
 	}
 
 	account = updateRedeemAccountLockedBalance(account, tx)
-	assert.Equal(t, value, account.LockedBalance["BTC"][extSenderAddress])
-	assert.Equal(t, value, account.EBalances["BTC"][extSenderAddress].Balance)
+	assert.Equal(t, value, account.LockedBalance[aSymbol.BTC][extSenderAddress])
+	assert.Equal(t, value, account.EBalances[aSymbol.BTC][extSenderAddress].Balance)
 }
 
 func TestValidatorGroups(t *testing.T) {

--- a/supervisor/transaction/service_test.go
+++ b/supervisor/transaction/service_test.go
@@ -5,7 +5,8 @@ import (
 
 	ed25519 "github.com/herdius/herdius-core/crypto/ed"
 	"github.com/herdius/herdius-core/crypto/secp256k1"
-"github.com/herdius/herdius-core/supervisor/transaction"
+	"github.com/herdius/herdius-core/supervisor/transaction"
+	"github.com/herdius/herdius-core/symbol"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -75,7 +76,7 @@ func getTx(nonce int) transaction.Tx {
 		Nonce:    string(nonce),
 		Fee:      "100",
 		Category: "Crypto",
-		Symbol:   "BTC",
+		Symbol:   symbol.BTC,
 		Value:    "10",
 		Network:  "Herdius",
 	}
@@ -99,7 +100,7 @@ func getTxUsingSecp256k1Account(nonce int) transaction.Tx {
 		Nonce:    string(nonce),
 		Fee:      "100",
 		Category: "Crypto",
-		Symbol:   "BTC",
+		Symbol:   symbol.BTC,
 		Value:    "10",
 		Network:  "Herdius",
 	}

--- a/symbol/symbol.go
+++ b/symbol/symbol.go
@@ -1,0 +1,14 @@
+package symbol
+
+const (
+	HER = "HER"
+	BTC = "BTC"
+	ETH = "ETH"
+	XTZ = "XTZ"
+	DAI = "DAI"
+	LTC = "LTC"
+
+	HBTC = "HBTC"
+	HTZX = "HTZX"
+	HLTC = "HLTC"
+)

--- a/syncer/btc.go
+++ b/syncer/btc.go
@@ -9,6 +9,7 @@ import (
 	"os"
 
 	"github.com/herdius/herdius-core/p2p/log"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 // BTCSyncer syncs all external BTC accounts.
@@ -19,7 +20,7 @@ type BTCSyncer struct {
 
 func newBTCSyncer() *BTCSyncer {
 	b := &BTCSyncer{}
-	b.syncer = newExternalSyncer("BTC")
+	b.syncer = newExternalSyncer(symbol.BTC)
 
 	return b
 }

--- a/syncer/btc_test.go
+++ b/syncer/btc_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/herdius/herdius-core/storage/db"
 	external "github.com/herdius/herdius-core/storage/exbalance"
 	"github.com/herdius/herdius-core/storage/state/statedb"
+	"github.com/herdius/herdius-core/symbol"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,8 +23,8 @@ func TestNoResponseFromAPI(t *testing.T) {
 
 	addr := "BTC-1"
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["BTC"] = make(map[string]statedb.EBalance)
-	eBalances["BTC"][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
+	eBalances[symbol.BTC] = make(map[string]statedb.EBalance)
+	eBalances[symbol.BTC][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances

--- a/syncer/btctestnet.go
+++ b/syncer/btctestnet.go
@@ -10,6 +10,7 @@ import (
 	"github.com/herdius/herdius-core/p2p/log"
 	external "github.com/herdius/herdius-core/storage/exbalance"
 	"github.com/herdius/herdius-core/storage/state/statedb"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 // BTCTestNetSyncer syncs all external BTC accounts in btctestnet.
@@ -38,7 +39,7 @@ func newBTCTestNetSyncer() *BTCTestNetSyncer {
 // GetExtBalance ...
 func (btc *BTCTestNetSyncer) GetExtBalance() error {
 
-	btcAccount, ok := btc.Account.EBalances["BTC"]
+	btcAccount, ok := btc.Account.EBalances[symbol.BTC]
 	if !ok {
 		return errors.New("BTC account does not exists")
 	}
@@ -76,7 +77,7 @@ func (btc *BTCTestNetSyncer) GetExtBalance() error {
 // Update updates accounts in cache as and when external balances
 // external chains are updated.
 func (btc *BTCTestNetSyncer) Update() {
-	assetSymbol := "BTC"
+	assetSymbol := symbol.BTC
 	for _, btcAccount := range btc.Account.EBalances[assetSymbol] {
 		if btc.addressError[btcAccount.Address] {
 			log.Warn().Msgf("Account info is not available at this moment, skip sync: %s", btcAccount.Address)

--- a/syncer/contract/erc20.go
+++ b/syncer/contract/erc20.go
@@ -661,4 +661,4 @@ func (_Token *TokenFilterer) WatchTransfer(opts *bind.WatchOpts, sink chan<- *To
 			}
 		}
 	}), nil
-} 
+}

--- a/syncer/dai.go
+++ b/syncer/dai.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/herdius/herdius-core/p2p/log"
+	"github.com/herdius/herdius-core/symbol"
 	"github.com/herdius/herdius-core/syncer/contract"
 )
 
@@ -22,7 +23,7 @@ type DaiSyncer struct {
 
 func newDAISyncer() *DaiSyncer {
 	d := &DaiSyncer{}
-	d.syncer = newExternalSyncer("DAI")
+	d.syncer = newExternalSyncer(symbol.DAI)
 
 	return d
 }

--- a/syncer/eth.go
+++ b/syncer/eth.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/herdius/herdius-core/p2p/log"
+	"github.com/herdius/herdius-core/symbol"
 	"github.com/tendermint/go-amino"
 )
 
@@ -21,7 +22,7 @@ type EthSyncer struct {
 
 func newEthSyncer() *EthSyncer {
 	e := &EthSyncer{}
-	e.syncer = newExternalSyncer("ETH")
+	e.syncer = newExternalSyncer(symbol.ETH)
 
 	return e
 }

--- a/syncer/external.go
+++ b/syncer/external.go
@@ -7,6 +7,7 @@ import (
 	"github.com/herdius/herdius-core/p2p/log"
 	external "github.com/herdius/herdius-core/storage/exbalance"
 	"github.com/herdius/herdius-core/storage/state/statedb"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 const (
@@ -40,7 +41,7 @@ func newExternalSyncer(assetSymbol string) *ExternalSyncer {
 }
 
 func (es *ExternalSyncer) isHBTC() bool {
-	return es.assetSymbol == "HBTC"
+	return es.assetSymbol == symbol.HBTC
 }
 
 func (es *ExternalSyncer) update(address string) {

--- a/syncer/external_test.go
+++ b/syncer/external_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/herdius/herdius-core/storage/db"
 	external "github.com/herdius/herdius-core/storage/exbalance"
 	"github.com/herdius/herdius-core/storage/state/statedb"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 func TestInit(t *testing.T) {
@@ -23,8 +24,8 @@ func TestInit(t *testing.T) {
 
 	addr := "ETH-1"
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["ETH"] = make(map[string]statedb.EBalance)
-	eBalances["ETH"][addr] = statedb.EBalance{Address: addr, Balance: uint64(0)}
+	eBalances[symbol.ETH] = make(map[string]statedb.EBalance)
+	eBalances[symbol.ETH][addr] = statedb.EBalance{Address: addr, Balance: uint64(0)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances
@@ -40,9 +41,9 @@ func TestInit(t *testing.T) {
 	es.Update()
 	cachedAcc, ok := accountCache.Get(account.Address)
 	assert.Equal(t, ok, true, "cache should return account")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].Balance, es.syncer.ExtBalance[addr].Uint64(), "Balance should be updated with external balance")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].LastBlockHeight, es.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].Nonce, es.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].Balance, es.syncer.ExtBalance[addr].Uint64(), "Balance should be updated with external balance")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].LastBlockHeight, es.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].Nonce, es.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
 
 }
 func TestExternalIsGreater(t *testing.T) {
@@ -58,9 +59,9 @@ func TestExternalIsGreater(t *testing.T) {
 	addr2 := "ETH-2"
 	storageKey := "ETH-" + addr
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["ETH"] = make(map[string]statedb.EBalance)
-	eBalances["ETH"][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
-	eBalances["ETH"][addr2] = statedb.EBalance{Address: addr2, Balance: uint64(18)}
+	eBalances[symbol.ETH] = make(map[string]statedb.EBalance)
+	eBalances[symbol.ETH][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
+	eBalances[symbol.ETH][addr2] = statedb.EBalance{Address: addr2, Balance: uint64(18)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances
@@ -76,12 +77,12 @@ func TestExternalIsGreater(t *testing.T) {
 	es.Update()
 	cachedAcc, ok := accountCache.Get(account.Address)
 	assert.Equal(t, ok, true, "cache should return account")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].Balance, es.syncer.ExtBalance[addr].Uint64(), "balance should be updated")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].Balance, es.syncer.ExtBalance[addr].Uint64(), "balance should be updated")
 	assert.Equal(t, cachedAcc.LastExtBalance[storageKey], big.NewInt(3), "LastExtBalance should be updated")
 	assert.Equal(t, cachedAcc.CurrentExtBalance[storageKey], big.NewInt(3), "CurrentExtBalance should be updated")
 	assert.Equal(t, cachedAcc.IsFirstEntry[storageKey], true, "IsFirstEntry should be updated")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].LastBlockHeight, es.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].Nonce, es.syncer.Nonce[addr], "Nonce should be updated with external nonce")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].LastBlockHeight, es.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].Nonce, es.syncer.Nonce[addr], "Nonce should be updated with external nonce")
 
 	es.syncer.ExtBalance[addr] = big.NewInt(20)
 	es.syncer.Nonce[addr] = 6
@@ -89,14 +90,14 @@ func TestExternalIsGreater(t *testing.T) {
 	es.Update()
 	cachedAcc, ok = accountCache.Get(account.Address)
 	assert.Equal(t, ok, true, "cache should return account")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].Balance, es.syncer.ExtBalance[addr].Uint64(), "Balance should be updated")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].Balance, es.syncer.ExtBalance[addr].Uint64(), "Balance should be updated")
 	assert.Equal(t, cachedAcc.IsFirstEntry[storageKey], false, "IsFirstEntry should be updated")
 	assert.Equal(t, cachedAcc.IsNewAmountUpdate[storageKey], true, "IsNewAmountUpdate should be updated")
 
 	assert.Equal(t, cachedAcc.LastExtBalance[storageKey], big.NewInt(20), "LastExtBalance should be updated")
 	assert.Equal(t, cachedAcc.CurrentExtBalance[storageKey], big.NewInt(20), "CurrentExtBalance should be updated")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].LastBlockHeight, es.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].Nonce, es.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].LastBlockHeight, es.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].Nonce, es.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
 }
 
 func TestExternalIsLesser(t *testing.T) {
@@ -111,8 +112,8 @@ func TestExternalIsLesser(t *testing.T) {
 	addr := "BTC-1"
 	storageKey := "BTC-" + addr
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["BTC"] = make(map[string]statedb.EBalance)
-	eBalances["BTC"][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
+	eBalances[symbol.BTC] = make(map[string]statedb.EBalance)
+	eBalances[symbol.BTC][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances
@@ -129,12 +130,12 @@ func TestExternalIsLesser(t *testing.T) {
 	cachedAcc, ok := accountCache.Get(account.Address)
 
 	assert.Equal(t, ok, true, "cache should return account")
-	assert.Equal(t, cachedAcc.Account.EBalances["BTC"][addr].Balance, bs.syncer.ExtBalance[addr].Uint64(), "Balance should be updated")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.BTC][addr].Balance, bs.syncer.ExtBalance[addr].Uint64(), "Balance should be updated")
 	assert.Equal(t, cachedAcc.LastExtBalance[storageKey], big.NewInt(10), "LastExtBalance should be updated")
 	assert.Equal(t, cachedAcc.CurrentExtBalance[storageKey], big.NewInt(10), "CurrentExtBalance should be updated")
 	assert.Equal(t, cachedAcc.IsFirstEntry[storageKey], true, "IsFirstEntry should be updated")
-	assert.Equal(t, cachedAcc.Account.EBalances["BTC"][addr].LastBlockHeight, bs.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
-	assert.Equal(t, cachedAcc.Account.EBalances["BTC"][addr].Nonce, bs.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.BTC][addr].LastBlockHeight, bs.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.BTC][addr].Nonce, bs.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
 
 	bs.syncer.ExtBalance[addr] = big.NewInt(1)
 	bs.syncer.Nonce[addr] = 7
@@ -146,8 +147,8 @@ func TestExternalIsLesser(t *testing.T) {
 	assert.Equal(t, cachedAcc.IsNewAmountUpdate[storageKey], true, "IsNewAmountUpdate should be updated")
 	assert.Equal(t, cachedAcc.LastExtBalance[storageKey], big.NewInt(1), "LastExtBalance should be updated")
 	assert.Equal(t, cachedAcc.CurrentExtBalance[storageKey], big.NewInt(1), "CurrentExtBalance should be updated")
-	assert.Equal(t, cachedAcc.Account.EBalances["BTC"][addr].LastBlockHeight, bs.syncer.BlockHeight[addr].Uint64(), "BlockHeight should be updated with external height")
-	assert.Equal(t, cachedAcc.Account.EBalances["BTC"][addr].Nonce, bs.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.BTC][addr].LastBlockHeight, bs.syncer.BlockHeight[addr].Uint64(), "BlockHeight should be updated with external height")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.BTC][addr].Nonce, bs.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
 }
 
 func TestCacheExistButWithoutAccountAsset(t *testing.T) {
@@ -162,8 +163,8 @@ func TestCacheExistButWithoutAccountAsset(t *testing.T) {
 	addr := "ETH-1"
 	storageKey := "ETH-" + addr
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["ETH"] = make(map[string]statedb.EBalance)
-	eBalances["ETH"][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
+	eBalances[symbol.ETH] = make(map[string]statedb.EBalance)
+	eBalances[symbol.ETH][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances
@@ -182,7 +183,7 @@ func TestCacheExistButWithoutAccountAsset(t *testing.T) {
 	cachedAcc, ok := accountCache.Get(account.Address)
 	assert.Equal(t, ok, true, "cache should return account")
 	assert.Equal(t, cachedAcc.LastExtBalance[storageKey], big.NewInt(10), "should be updated")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].LastBlockHeight, es.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].Nonce, es.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].LastBlockHeight, es.syncer.BlockHeight[addr].Uint64(), "LastBlockHeight should be updated with external height")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].Nonce, es.syncer.Nonce[addr], "Nonce should be updated with external Nonce")
 
 }

--- a/syncer/hbtc.go
+++ b/syncer/hbtc.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/herdius/herdius-core/p2p/log"
 	"github.com/herdius/herdius-core/storage/state/statedb"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 // HBTCSyncer syncs all HBTC external accounts
@@ -21,7 +22,7 @@ type HBTCSyncer struct {
 }
 
 func newHBTCSyncer() *HBTCSyncer {
-	h := &HBTCSyncer{symbol: "HBTC", ethSymbol: "ETH"}
+	h := &HBTCSyncer{symbol: symbol.HBTC, ethSymbol: symbol.ETH}
 	h.syncer = newExternalSyncer(h.symbol)
 
 	return h

--- a/syncer/hbtc_test.go
+++ b/syncer/hbtc_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/herdius/herdius-core/storage/db"
 	external "github.com/herdius/herdius-core/storage/exbalance"
 	"github.com/herdius/herdius-core/storage/state/statedb"
+	"github.com/herdius/herdius-core/symbol"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,15 +23,15 @@ func TestInitHBTC(t *testing.T) {
 
 	addr := "ETH-1"
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["ETH"] = make(map[string]statedb.EBalance)
-	eBalances["ETH"][addr] = statedb.EBalance{Address: addr, Balance: uint64(0)}
-	eBalances["HBTC"] = make(map[string]statedb.EBalance)
-	eBalances["HBTC"][addr] = statedb.EBalance{Address: addr, Balance: uint64(0)}
+	eBalances[symbol.ETH] = make(map[string]statedb.EBalance)
+	eBalances[symbol.ETH][addr] = statedb.EBalance{Address: addr, Balance: uint64(0)}
+	eBalances[symbol.HBTC] = make(map[string]statedb.EBalance)
+	eBalances[symbol.HBTC][addr] = statedb.EBalance{Address: addr, Balance: uint64(0)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances
 	account.Address = "testEthAddress1"
-	account.FirstExternalAddress = map[string]string{"ETH": addr}
+	account.FirstExternalAddress = map[string]string{symbol.ETH: addr}
 
 	hs := newHBTCSyncer()
 	hs.syncer.Account = account
@@ -39,7 +40,7 @@ func TestInitHBTC(t *testing.T) {
 	hs.Update()
 	cachedAcc, ok := accountCache.Get(account.Address)
 	assert.Equal(t, ok, true, "cache should return account")
-	assert.Equal(t, hs.syncer.ExtBalance[addr].Uint64(), cachedAcc.Account.EBalances["HBTC"][addr].Balance, "HBTC Balance should be updated with external balance")
+	assert.Equal(t, hs.syncer.ExtBalance[addr].Uint64(), cachedAcc.Account.EBalances[symbol.HBTC][addr].Balance, "HBTC Balance should be updated with external balance")
 }
 
 func TestExternalHBTCisGreater(t *testing.T) {
@@ -53,15 +54,15 @@ func TestExternalHBTCisGreater(t *testing.T) {
 
 	addr := "ETH-1"
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["ETH"] = make(map[string]statedb.EBalance)
-	eBalances["ETH"][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
-	eBalances["HBTC"] = make(map[string]statedb.EBalance)
-	eBalances["HBTC"][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
+	eBalances[symbol.ETH] = make(map[string]statedb.EBalance)
+	eBalances[symbol.ETH][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
+	eBalances[symbol.HBTC] = make(map[string]statedb.EBalance)
+	eBalances[symbol.HBTC][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances
 	account.Address = "testEthAddress"
-	account.FirstExternalAddress = map[string]string{"ETH": addr}
+	account.FirstExternalAddress = map[string]string{symbol.ETH: addr}
 
 	hs := newHBTCSyncer()
 	hs.syncer.Account = account
@@ -76,7 +77,7 @@ func TestExternalHBTCisGreater(t *testing.T) {
 
 	cachedAcc, ok := accountCache.Get(account.Address)
 	assert.Equal(t, ok, true, "cache should return account")
-	assert.Equal(t, hs.syncer.ExtBalance[addr].Uint64(), cachedAcc.Account.EBalances["HBTC"][addr].Balance, "HBTC Balance should be updated")
+	assert.Equal(t, hs.syncer.ExtBalance[addr].Uint64(), cachedAcc.Account.EBalances[symbol.HBTC][addr].Balance, "HBTC Balance should be updated")
 }
 
 func TestExternalHBTCisLesser(t *testing.T) {
@@ -90,15 +91,15 @@ func TestExternalHBTCisLesser(t *testing.T) {
 
 	addr := "ETH-1"
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["ETH"] = make(map[string]statedb.EBalance)
-	eBalances["ETH"][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
-	eBalances["HBTC"] = make(map[string]statedb.EBalance)
-	eBalances["HBTC"][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
+	eBalances[symbol.ETH] = make(map[string]statedb.EBalance)
+	eBalances[symbol.ETH][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
+	eBalances[symbol.HBTC] = make(map[string]statedb.EBalance)
+	eBalances[symbol.HBTC][addr] = statedb.EBalance{Address: addr, Balance: uint64(8)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances
 	account.Address = "testEthAddress"
-	account.FirstExternalAddress = map[string]string{"ETH": addr}
+	account.FirstExternalAddress = map[string]string{symbol.ETH: addr}
 
 	hs := newHBTCSyncer()
 	hs.syncer.Account = account
@@ -113,6 +114,6 @@ func TestExternalHBTCisLesser(t *testing.T) {
 
 	cachedAcc, ok := accountCache.Get(account.Address)
 	assert.Equal(t, ok, true, "cache should return account")
-	assert.Equal(t, hs.syncer.ExtBalance[addr].Uint64(), cachedAcc.Account.EBalances["HBTC"][addr].Balance, "HBTC Balance should be updated")
+	assert.Equal(t, hs.syncer.ExtBalance[addr].Uint64(), cachedAcc.Account.EBalances[symbol.HBTC][addr].Balance, "HBTC Balance should be updated")
 
 }

--- a/syncer/tezos.go
+++ b/syncer/tezos.go
@@ -6,6 +6,7 @@ import (
 
 	goTezos "github.com/DefinitelyNotAGoat/go-tezos"
 	"github.com/herdius/herdius-core/p2p/log"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 // TezosSyncer syncs all XTZ external accounts
@@ -16,7 +17,7 @@ type TezosSyncer struct {
 
 func newTezosSyncer() *TezosSyncer {
 	t := &TezosSyncer{}
-	t.syncer = newExternalSyncer("XTZ")
+	t.syncer = newExternalSyncer(symbol.XTZ)
 
 	return t
 }

--- a/syncer/token_test.go
+++ b/syncer/token_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/herdius/herdius-core/storage/db"
 	external "github.com/herdius/herdius-core/storage/exbalance"
 	"github.com/herdius/herdius-core/storage/state/statedb"
+	"github.com/herdius/herdius-core/symbol"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,8 +29,8 @@ func TestHERShouldNOTChangeOtherASSET(t *testing.T) {
 	addr := "ETH-1"
 	storageKey := "ETH-" + addr
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["ETH"] = make(map[string]statedb.EBalance)
-	eBalances["ETH"][addr] = statedb.EBalance{Balance: uint64(1)}
+	eBalances[symbol.ETH] = make(map[string]statedb.EBalance)
+	eBalances[symbol.ETH][addr] = statedb.EBalance{Balance: uint64(1)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances
@@ -51,7 +52,7 @@ func TestHERShouldNOTChangeOtherASSET(t *testing.T) {
 	cachedAcc, ok = accountCache.Get(account.Address)
 	assert.Equal(t, ok, true, "cache should return account")
 
-	assert.Equal(t, cachedAcc.Account.EBalances["ETH"][addr].Balance, uint64(1), "Balance should not be updated with external balance")
+	assert.Equal(t, cachedAcc.Account.EBalances[symbol.ETH][addr].Balance, uint64(1), "Balance should not be updated with external balance")
 	assert.Equal(t, cachedAcc.LastExtBalance[storageKey], big.NewInt(9), "LastExtBalance should not be updated with external balance")
 	assert.Equal(t, cachedAcc.Account.Balance, big.NewInt(1).Uint64(), "Balance should not be updated with external balance")
 
@@ -68,8 +69,8 @@ func TestHERExternalETHisGreater(t *testing.T) {
 
 	addr := "ETH-1"
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["ETH"] = make(map[string]statedb.EBalance)
-	eBalances["ETH"][addr] = statedb.EBalance{Balance: uint64(8)}
+	eBalances[symbol.ETH] = make(map[string]statedb.EBalance)
+	eBalances[symbol.ETH][addr] = statedb.EBalance{Balance: uint64(8)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances
@@ -119,8 +120,8 @@ func TestHERExternalETHisLesser(t *testing.T) {
 
 	addr := "ETH-1"
 	eBalances := make(map[string]map[string]statedb.EBalance)
-	eBalances["ETH"] = make(map[string]statedb.EBalance)
-	eBalances["ETH"][addr] = statedb.EBalance{Balance: uint64(8)}
+	eBalances[symbol.ETH] = make(map[string]statedb.EBalance)
+	eBalances[symbol.ETH][addr] = statedb.EBalance{Balance: uint64(8)}
 
 	account := statedb.Account{}
 	account.EBalances = eBalances

--- a/tx/protobuf/stream.pb.go
+++ b/tx/protobuf/stream.pb.go
@@ -5,8 +5,9 @@ package protobuf
 
 import (
 	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
 	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/tx/service_test.go
+++ b/tx/service_test.go
@@ -12,6 +12,7 @@ import (
 	cmn "github.com/herdius/herdius-core/libs/common"
 	. "github.com/herdius/herdius-core/libs/test"
 	"github.com/herdius/herdius-core/supervisor/transaction"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 var service Service
@@ -138,7 +139,7 @@ func getTx(nonce int) transaction.Tx {
 		Nonce:    string(nonce),
 		Fee:      "100",
 		Category: "Crypto",
-		Symbol:   "BTC",
+		Symbol:   symbol.BTC,
 		Value:    "10",
 		Network:  "Herdius",
 	}

--- a/types/aminoregister.go
+++ b/types/aminoregister.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"github.com/herdius/herdius-core/crypto/encoding/amino"
+	cryptoAmino "github.com/herdius/herdius-core/crypto/encoding/amino"
 	amino "github.com/tendermint/go-amino"
 )
 

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -10,6 +10,7 @@ import (
 	cmn "github.com/herdius/herdius-core/libs/common"
 	ctest "github.com/herdius/herdius-core/libs/test"
 	"github.com/herdius/herdius-core/supervisor/transaction"
+	"github.com/herdius/herdius-core/symbol"
 )
 
 func makeTxs(cnt, size int) Txs {
@@ -31,7 +32,7 @@ func createTx(nonce int) transaction.Tx {
 		Nonce:    string(nonce),
 		Fee:      "100",
 		Category: "Crypto",
-		Symbol:   "BTC",
+		Symbol:   symbol.BTC,
 		Value:    "10",
 		Network:  "Herdius",
 	}


### PR DESCRIPTION
## Problem

Notion Link: https://www.notion.so/herdius/b081bd4254c14b1eb2ada917ce4ef406?v=7fec7434ea0849afa3c4db6676e9eb76&p=5faa88f17a64453fb01cdee1fdd00ed9

## Solution

Introduce package symbol to define all asset symbol string there.

## Testing Done and Results

Passed.

## Follow-up Work Needed

All future PRs should use this package instead of string literal, `symbol.BTC` instead of `"BTC"`.