### PR TITLE
Balance issue in syncer

### DIFF
--- a/syncer/external.go
+++ b/syncer/external.go
@@ -97,6 +97,21 @@ func (es *ExternalSyncer) update(address string) {
 				}
 				log.Debug().Msgf("New account balance after external balance debit: %v\n", last)
 			}
+			if lastExtBalance.Cmp(es.ExtBalance[assetAccount.Address]) == 0 {
+				assetAccount.Balance = 0
+				if es.BlockHeight[assetAccount.Address] != nil {
+					assetAccount.LastBlockHeight = es.BlockHeight[assetAccount.Address].Uint64()
+				}
+				assetAccount.Nonce = es.Nonce[assetAccount.Address]
+				es.Account.EBalances[assetSymbol][assetAccount.Address] = assetAccount
+
+				last = last.UpdateLastExtBalanceByKey(storageKey, es.ExtBalance[assetAccount.Address])
+				last = last.UpdateCurrentExtBalanceByKey(storageKey, es.ExtBalance[assetAccount.Address])
+				last = last.UpdateIsFirstEntryByKey(storageKey, false)
+				last = last.UpdateIsNewAmountUpdateByKey(storageKey, true)
+				last = last.UpdateAccount(es.Account)
+				es.Storage.Set(es.Account.Address, last)
+			}
 			return
 		}
 


### PR DESCRIPTION
## Problem

Lock BTC tx, Redeem HBTC tx and again Lock BTC tx has resulted in incorrect HBTC balance getting updated by syncer since the last cache was still having balance of HBTC from first lock tx.

Notion Link: 

## Solution

## Testing Done and Results

## Follow-up Work Needed
