### PR TITLE
hbi,blockchain: fix create tx id

### DIFF
--- a/blockchain/service.go
+++ b/blockchain/service.go
@@ -873,6 +873,7 @@ func GetBlockchainDb() db.DB {
 func getTxIDWithoutStatus(tx *pluginproto.Tx) string {
 	txWithOutStatus := *tx
 	txWithOutStatus.Status = ""
+	txWithOutStatus.ExternalAddress = nil
 	txbzWithOutStatus, _ := cdc.MarshalJSON(txWithOutStatus)
 	txID := cmn.CreateTxID(txbzWithOutStatus)
 	return txID

--- a/hbi/message/plugin.go
+++ b/hbi/message/plugin.go
@@ -272,6 +272,11 @@ func (state *TransactionMessagePlugin) Receive(ctx *network.PluginContext) error
 			return errors.New("Not enough balance: " + strconv.FormatUint(uint64(msg.Tx.GetAsset().Value), 10))
 		}
 
+		defer func(m map[string]string) {
+			tx.ExternalAddress = m
+		}(tx.ExternalAddress)
+		tx.ExternalAddress = nil
+
 		// Add Tx to Mempool
 		mp := mempool.GetMemPool()
 		txbz, err := cdc.MarshalJSON(tx)
@@ -347,6 +352,10 @@ func (state *TransactionMessagePlugin) Receive(ctx *network.PluginContext) error
 }
 
 func postAccountUpdateTx(tx *protoplugin.Tx, ctx *network.PluginContext, as account.ServiceI) error {
+	defer func(m map[string]string) {
+		tx.ExternalAddress = m
+	}(tx.ExternalAddress)
+	tx.ExternalAddress = nil
 	// Add Tx to Mempool
 	mp := mempool.GetMemPool()
 	txbz, err := cdc.MarshalJSON(tx)


### PR DESCRIPTION
## Problem

Transaction ID is created base on protobuf.Tx payload. Since when we
added ExternalAddress to protobuf.Tx payload, it's a map, so the order
of key-element is not specified. So when we marshal json it, the data
return can be different between runs.

To fix it, we can exclude ExternalAddress from tx payload.

Notion Link: https://www.notion.so/herdius/Tx-detail-pending-status-still-persists-bf2ff1dff490480eb450b4a675ef50d4

## Solution

Exclude external address before marshal JSON tx.

## Testing Done and Results

Passed.

## Follow-up Work Needed
